### PR TITLE
added cdn link to readme for ease of use

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ULabel is an entirely "frontend" tool. It can be incorporated into any HTML page
 <!DOCTYPE html>
 <html>
 <head>
-    <script src="/ulabel.js"></script>
+    <script src="https://unpkg.com/ulabel/dist/ulabel.js"></script>
 </head>
 <body>
     <div id="ulabel-container" style="height: 800px; width: 1200px; position: absolute; top: 0; left: 0;"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "ulabel",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "express": "^4.17.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ulabel",
   "description": "An image annotation tool.",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-exports.ULABEL_VERSION = "0.3.2";
+exports.ULABEL_VERSION = "0.3.3";


### PR DESCRIPTION
# Added cdn link to readme for ease of use

## Description

Now that the file is on npm, we can direct people the unpkg cdn for the frontend-only use case.

## PR Checklist
- [x] Merged latest master
- [x] Updated version number in `package.json`
- [x] Version numbers match between package `package.json` and `src/version.js`

## API Changes

None,
