### PR TITLE
V4 updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,23 @@ A browser-based tool for annotating images.
 
 ## Usage
 
-ULabel is an entirely "frontend" tool. It can be incorporated into any HTML page as follows:
+ULabel is an entirely "frontend" tool. It can be incorporated into any HTML page using either the unpkg cdn
+
+```html
+<script src="https://unpkg.com/ulabel/dist/ulabel.js"></script>
+```
+
+Or you can use npm to install it and serve the `dist/ulabel.js` file from `node_modules` locally.
+
+```bash
+npm install ulabel
+```
+
+```html
+<script src="/node_modules/ulabel/dist/ulabel.js"></script>
+```
+
+Once the script is included in your HTML doc, you can create a ULabel annotation session as follows.
 
 ```html
 <!DOCTYPE html>
@@ -73,7 +89,7 @@ ULabel is an entirely "frontend" tool. It can be incorporated into any HTML page
 </html>
 ```
 
-## Demo/Development
+## Development
 
 The recommended way to develop new features is to use the tool as if you were running the demo. For testing new API features, you can create a new HTML file in `demo/`. The server in `demo.js` runs a static server from `demo/` so it will be served at `localhost:8080/<new-file>.html` automatically.
 
@@ -96,7 +112,7 @@ pwd # Should be /path/to/ulabel
 node demo.js
 ```
 
-### Develop & Build
+### Build
 
 The repository ships with the built `dist/ulabel.js` file. This file is not to be edited directly. Edits should be made in the `src/` dir and the package is built with 
 

--- a/README.md
+++ b/README.md
@@ -123,9 +123,3 @@ npm run build
 ## Attribution
 
 The three demo images were downloaded from the [CityScapes dataset](https://www.cityscapes-dataset.com/). In particular, they are sampled from the first few frames of the `leftImg8bit_demoVideo`.
-
-## v0.4.0 TODO List
-
-- ~~Adjust threshold for depositing new contour point using px_per_px~~
-- ~~Allow for custom done_button display~~
-- Allow for subtasks to be "Read Only"

--- a/README.md
+++ b/README.md
@@ -107,3 +107,9 @@ npm run build
 ## Attribution
 
 The three demo images were downloaded from the [CityScapes dataset](https://www.cityscapes-dataset.com/). In particular, they are sampled from the first few frames of the `leftImg8bit_demoVideo`.
+
+## v0.4.0 TODO List
+
+- ~~Adjust threshold for depositing new contour point using px_per_px~~
+- ~~Allow for custom done_button display~~
+- Allow for subtasks to be "Read Only"

--- a/demo/frames.html
+++ b/demo/frames.html
@@ -52,7 +52,8 @@
                         "allowed_modes": ["bbox", "polygon", "contour", "bbox3"],
                         "resume_from": null,
                         "task_meta": null,
-                        "annotation_meta": null
+                        "annotation_meta": null,
+                        "read_only": false
                     },
                     "frame_review": {
                         "display_name": "Frame Review",
@@ -71,7 +72,8 @@
                         "allowed_modes": ["whole-image"],
                         "resume_from": null,
                         "task_meta": null,
-                        "annotation_meta": null
+                        "annotation_meta": null,
+                        "read_only": false
                     }
                 };
 

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -11537,7 +11537,7 @@ function version(uuid) {
 /***/ 345:
 /***/ ((__unused_webpack_module, exports) => {
 
-exports.I = "0.3.2";
+exports.I = "0.3.3";
 
 /***/ })
 
@@ -14194,7 +14194,7 @@ class ULabel {
         jquery_default()("#" + sp_id + " .toolbox_inner_cls .mode-selection").append(md_buttons.join("<!-- -->"));
         // TODO noconflict
         jquery_default()("#" + sp_id + " .toolbox_inner_cls").append(`
-            <a href="#" id="submit-button">Submit</a>
+            <a href="#" id="submit-button">${ul.config["done_button"]}</a>
         `);
 
         // Show current mode label
@@ -14991,6 +14991,18 @@ class ULabel {
         if (task_meta == null) {task_meta = {};}
         if (annotation_meta == null) {annotation_meta = {};}
 
+        // Unroll submit button
+        let on_submit_unrolled;
+        if (typeof on_submit == "function") {
+            on_submit_unrolled = {
+                name: "Submit",
+                hook: on_submit
+            };
+        }
+        else {
+            on_submit_unrolled = on_submit;
+        }
+
         // TODO 
         // Allow for importing spacing data -- a measure tool would be nice too
         // Much of this is hardcoded defaults, 
@@ -15025,7 +15037,8 @@ class ULabel {
             "edit_handle_size": 30,
 
             // Behavior on special interactions
-            "done_callback": on_submit,
+            "done_callback": on_submit_unrolled.hook,
+            "done_button": on_submit_unrolled.name,
 
             // ID Dialog config
             "cl_opacity": 0.4,
@@ -16967,7 +16980,7 @@ class ULabel {
                     this.redraw_all_annotations(this.state["current_subtask"], null, true); // tobuffer
                     break;
                 case "contour":
-                    if (ULabel.l2_norm(ms_loc, this.subtasks[this.state["current_subtask"]]["annotations"]["access"][actid]["spatial_payload"][this.subtasks[this.state["current_subtask"]]["annotations"]["access"][actid]["spatial_payload"].length-1]) > 3) {
+                    if (ULabel.l2_norm(ms_loc, this.subtasks[this.state["current_subtask"]]["annotations"]["access"][actid]["spatial_payload"][this.subtasks[this.state["current_subtask"]]["annotations"]["access"][actid]["spatial_payload"].length-1])*this.config["px_per_px"] > 3) {
                         this.subtasks[this.state["current_subtask"]]["annotations"]["access"][actid]["spatial_payload"].push(ms_loc);
                         this.update_containing_box(ms_loc, actid);
                         this.redraw_all_annotations(this.state["current_subtask"], null, true); // TODO tobuffer, no need to redraw here, can just draw over

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -13963,9 +13963,11 @@ class ULabel {
             let sel = "";
             let href = ` href="#"`;
             let val = 50;
+            if (st_key == ul.state["current_subtask"] || ul.subtasks[st_key]["read_only"]) {
+                href = "";
+            }
             if (st_key == ul.state["current_subtask"]) {
                 sel = " sel";
-                href = "";
                 val = 100;
             }
             ret += `
@@ -14863,14 +14865,20 @@ class ULabel {
     }
 
     static initialize_subtasks(ul, stcs) {
+        let first_non_ro = null;
         for (const subtask_key in stcs) {
             // For convenience, make a raw subtask var
             let raw_subtask = stcs[subtask_key];
 
             // Initialize subtask config to null
             ul.subtasks[subtask_key] = {
-                "display_name": raw_subtask["display_name"] || subtask_key
+                "display_name": raw_subtask["display_name"] || subtask_key,
+                "read_only": ("read_only" in raw_subtask) && (raw_subtask["read_only"] === true)
             };
+
+            if (first_non_ro == null && !ul.subtasks[subtask_key]["read_only"]) {
+                first_non_ro = subtask_key;
+            }
 
             //  Initialize an empty action stream for each subtask
             ul.subtasks[subtask_key]["actions"] = {
@@ -14924,7 +14932,9 @@ class ULabel {
                 // Generic dialogs
                 "visible_dialogs": {}
             };
-
+        }
+        if (first_non_ro == null) {
+            ul.raise_error("You must have at least one subtask without 'read_only' set to true.", ULabel.elvl_fatal);
         }
     }
 
@@ -17724,6 +17734,7 @@ class ULabel {
                 break;
             case ULabel.elvl_fatal:
                 alert("[fatal] " + message);
+                throw new Error(message);
                 break;
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "ulabel",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.3.3",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "express": "^4.17.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ulabel",
   "description": "An image annotation tool.",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/src/index.js
+++ b/src/index.js
@@ -588,7 +588,7 @@ class ULabel {
         $("#" + sp_id + " .toolbox_inner_cls .mode-selection").append(md_buttons.join("<!-- -->"));
         // TODO noconflict
         $("#" + sp_id + " .toolbox_inner_cls").append(`
-            <a href="#" id="submit-button">Submit</a>
+            <a href="#" id="submit-button">${ul.config["done_button"]}</a>
         `);
 
         // Show current mode label
@@ -1385,6 +1385,18 @@ class ULabel {
         if (task_meta == null) {task_meta = {};}
         if (annotation_meta == null) {annotation_meta = {};}
 
+        // Unroll submit button
+        let on_submit_unrolled;
+        if (typeof on_submit == "function") {
+            on_submit_unrolled = {
+                name: "Submit",
+                hook: on_submit
+            };
+        }
+        else {
+            on_submit_unrolled = on_submit;
+        }
+
         // TODO 
         // Allow for importing spacing data -- a measure tool would be nice too
         // Much of this is hardcoded defaults, 
@@ -1419,7 +1431,8 @@ class ULabel {
             "edit_handle_size": 30,
 
             // Behavior on special interactions
-            "done_callback": on_submit,
+            "done_callback": on_submit_unrolled.hook,
+            "done_button": on_submit_unrolled.name,
 
             // ID Dialog config
             "cl_opacity": 0.4,
@@ -3361,7 +3374,7 @@ class ULabel {
                     this.redraw_all_annotations(this.state["current_subtask"], null, true); // tobuffer
                     break;
                 case "contour":
-                    if (ULabel.l2_norm(ms_loc, this.subtasks[this.state["current_subtask"]]["annotations"]["access"][actid]["spatial_payload"][this.subtasks[this.state["current_subtask"]]["annotations"]["access"][actid]["spatial_payload"].length-1]) > 3) {
+                    if (ULabel.l2_norm(ms_loc, this.subtasks[this.state["current_subtask"]]["annotations"]["access"][actid]["spatial_payload"][this.subtasks[this.state["current_subtask"]]["annotations"]["access"][actid]["spatial_payload"].length-1])*this.config["px_per_px"] > 3) {
                         this.subtasks[this.state["current_subtask"]]["annotations"]["access"][actid]["spatial_payload"].push(ms_loc);
                         this.update_containing_box(ms_loc, actid);
                         this.redraw_all_annotations(this.state["current_subtask"], null, true); // TODO tobuffer, no need to redraw here, can just draw over

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-exports.ULABEL_VERSION = "0.3.3";
+exports.ULABEL_VERSION = "0.4.0";


### PR DESCRIPTION
# Custom Done Button and Read-Only Subtasks

## Description

The text on the "Submit" button is now able to be customized with the ULabel constructor as follows

```javascript
let ulabel = new ULabel(
    "container", 
    ["/images/cs-demo-0.png", "/images/cs-demo-1.png", "/images/cs-demo-2.png"], 
    "DemoUser",
    {
        "name": "<custom text here>",
        "hook": on_submit
    },
    subtasks
);
```

Additionally, subtasks may now be specified as read-only by including a `read_only: true` attribute in the subtask configuration, but an annotation must have at least one subtask that is not read-only, otherwise a fatal error is thrown during construction.

## PR Checklist
- [x] Merged latest master
- [x] Updated version number in `package.json`
- [x] Version numbers match between package `package.json` and `src/version.js`

## API Changes

See description.