### PR TITLE
Nonspatial Annotations in resume_from

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
-<nothing_yet>
+- Bugfix for resuming from nonspatial annotations
 
 ## [0.4.6] - March 9, 2021
 

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -13630,7 +13630,7 @@ const COLORS = [
 
 
 ;// CONCATENATED MODULE: ./src/version.js
-const ULABEL_VERSION = "0.4.6";
+const ULABEL_VERSION = "0.4.7";
 ;// CONCATENATED MODULE: ./src/index.js
 /*
 Uncertain Labeling Tool
@@ -15108,11 +15108,6 @@ class ULabel {
         // Useful for the efficient redraw of nonspatial annotations
         this.tmp_nonspatial_element_ids = {};
 
-        // Populate these in an external "static" function
-        this.subtasks = {};
-        this.tot_num_classes = 0;
-        ULabel.initialize_subtasks(this, subtasks);
-
         // Create object for current ulabel state
         this.state = {
             // Viewer state
@@ -15129,6 +15124,11 @@ class ULabel {
             // Renderings state
             "demo_canvas_context": null
         };
+
+        // Populate these in an external "static" function
+        this.subtasks = {};
+        this.tot_num_classes = 0;
+        ULabel.initialize_subtasks(this, subtasks);
 
         // Create object for dragging interaction state
         // TODO(v1)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "ulabel",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.4.6",
+      "version": "0.4.7",
       "license": "MIT",
       "dependencies": {
         "express": "^4.17.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ulabel",
   "description": "An image annotation tool.",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/src/index.js
+++ b/src/index.js
@@ -1486,11 +1486,6 @@ class ULabel {
         // Useful for the efficient redraw of nonspatial annotations
         this.tmp_nonspatial_element_ids = {};
 
-        // Populate these in an external "static" function
-        this.subtasks = {};
-        this.tot_num_classes = 0;
-        ULabel.initialize_subtasks(this, subtasks);
-
         // Create object for current ulabel state
         this.state = {
             // Viewer state
@@ -1507,6 +1502,11 @@ class ULabel {
             // Renderings state
             "demo_canvas_context": null
         };
+
+        // Populate these in an external "static" function
+        this.subtasks = {};
+        this.tot_num_classes = 0;
+        ULabel.initialize_subtasks(this, subtasks);
 
         // Create object for dragging interaction state
         // TODO(v1)

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export const ULABEL_VERSION = "0.4.6";
+export const ULABEL_VERSION = "0.4.7";


### PR DESCRIPTION
# Nonspatial Annotations in resume_from

## Description

There was an issue resuming from sessions with nonspatial annotations. `this.state` was being referenced before set. This has been fixed. 

## PR Checklist

- [x] Merged latest master
- [x] Version number in `package.json` has been bumped since last release
- [x] Version numbers match between package `package.json` and `src/version.js`
- [x] Ran `npm install` and `npm run build` AFTER bumping the version number
- [x] Updated documentation if necessary (currently just in `api_spec.md`)
- [x] Added changes to `changelog.md`

## Breaking API Changes

None.