### PR TITLE
Added Getter and Setter

### DIFF
--- a/api_spec.md
+++ b/api_spec.md
@@ -261,11 +261,11 @@ Display utilities are provided for a constructed `ULabel` object.
 
 ### `get_annotations(subtask)`
 
-TODO
+*(string) => array* -- Gets the current list of annotations within the provided subtask.
 
 ### `set_annotations(new_annotations, subtask)`
 
-TODO
+*(array, string) => void* -- Sets the annotations for the provided subtask.
 
 ## Generic Callbacks
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented here.
 ## [Unreleased]
 
 - Bugfix for resuming from nonspatial annotations
+- Created interface for `get` and `set` to allow for custom annotation processing
+- Changed to more inclusive keyboard event handling
 
 ## [0.4.6] - March 9, 2021
 

--- a/demo/getset.html
+++ b/demo/getset.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>ULabel</title>
+
+        <!-- ULabel Library -->
+        <script src="/ulabel.js"></script>
+
+        <!-- JQuery Library -->
+        <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+
+        <!-- ULabel Usage -->
+        <script>
+            /* global $ */
+            /* global ULabel */
+
+            $(window).on("load", function() {
+
+                let on_submit = (annotations) => {
+                    var element = document.createElement('a');
+                    element.setAttribute(
+                        "href", ('data:text/plain;charset=utf-8,' + 
+                        encodeURIComponent(JSON.stringify(annotations, null, 2)))
+                    );
+                    element.setAttribute("download", "annotations.json");
+                    element.style.display = 'none';
+                    document.body.appendChild(element);
+                    element.click();
+                    document.body.removeChild(element);
+                }
+
+                let subtasks = {
+                    "car_detection": {
+                        "display_name": "Car Detection",
+                        "classes": [
+                            {
+                                "name": "Sedan",
+                                "color": "blue",
+                                "id": 10
+                            },
+                            {
+                                "name": "SUV",
+                                "color": "green",
+                                "id": 11
+                            },
+                            {
+                                "name": "Truck",
+                                "color": "orange",
+                                "id": 12
+                            },
+                        ],
+                        "allowed_modes": ["bbox", "polygon", "contour", "bbox3"],
+                        "resume_from": null,
+                        "task_meta": null,
+                        "annotation_meta": null,
+                        "read_only": false,
+                        "inactive_opacity": 0.6
+                    },
+                    "frame_review": {
+                        "display_name": "Frame Review",
+                        "classes": [
+                            {
+                                "name": "Blurry",
+                                "color": "gray",
+                                "id": 20
+                            },
+                            {
+                                "name": "Occluded",
+                                "color": "red",
+                                "id": 21
+                            }
+                        ],
+                        "allowed_modes": ["whole-image", "global"],
+                        "resume_from": null,
+                        "task_meta": null,
+                        "annotation_meta": null,
+                        "read_only": false
+                    }
+                };
+
+                // Initial ULabel configuration
+                let ulabel = new ULabel(
+                    "container",
+                    [
+                        "https://ulabel.s3.us-east-2.amazonaws.com/cs-demo-0.png", 
+                        "https://ulabel.s3.us-east-2.amazonaws.com/cs-demo-1.png", 
+                        "https://ulabel.s3.us-east-2.amazonaws.com/cs-demo-2.png"
+                    ],
+                    "DemoUser",
+                    on_submit,
+                    subtasks,
+                    null,
+                    null,
+                    1,
+                    null
+                );
+                // Wait for ULabel instance to finish initialization
+                ulabel.init(function() {
+                    // ULabel is now ready for use
+                    document.body.onkeydown = function(keypress_event) {
+                        if (keypress_event.key == "g") {
+                            let anns = ulabel.get_annotations("car_detection");
+                            for (let i = 0; i < anns.length; i++) {
+                                for (let j = 0; j < anns[i]["spatial_payload"].length; j++) {
+                                    anns[i]["spatial_payload"][j][0] += 10;
+                                }
+                            }
+                            ulabel.set_annotations(anns, "car_detection");
+                        }
+                    };
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="container" style="width: 100%; height: 100vh; position: absolute; top: 0; left: 0;"></div>
+    </body>
+</html>

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -13306,6 +13306,11 @@ div#${prntid} div.dialogs_container {
    left: 0;
 }
 
+div.toolbox_inner_cls {
+   height: calc(100% - 38px);
+   overflow-y: scroll;
+}
+
 /* ========== Tab Buttons ========== */
 
 div#${prntid} div.toolbox-tabs {
@@ -13516,20 +13521,20 @@ div#${prntid}.ulabel-night div.night-status {
 }
 
 
-div#${prntid}.ulabel-night div.annbox_cls::-webkit-scrollbar {
+div#${prntid}.ulabel-night *::-webkit-scrollbar {
    background-color: black;
 }
-div#${prntid}.ulabel-night div.annbox_cls::-webkit-scrollbar-track {
+div#${prntid}.ulabel-night *::-webkit-scrollbar-track {
    background-color: black;
 }
-div#${prntid}.ulabel-night div.annbox_cls::-webkit-scrollbar-thumb {
+div#${prntid}.ulabel-night *::-webkit-scrollbar-thumb {
    border: 1px solid rgb(110, 110, 110);
    background-color: rgb(51, 51, 51);
 }
-div#${prntid}.ulabel-night div.annbox_cls::-webkit-scrollbar-thumb:hover {
+div#${prntid}.ulabel-night *::-webkit-scrollbar-thumb:hover {
    background-color: rgb(90, 90, 90);
 } 
-div#${prntid}.ulabel-night div.annbox_cls::-webkit-scrollbar-corner {
+div#${prntid}.ulabel-night *::-webkit-scrollbar-corner {
    background-color:rgb(0, 60, 95);
 }
 
@@ -14521,6 +14526,9 @@ class ULabel {
         new ResizeObserver(function() {
             ul.reposition_dialogs();
         }).observe(document.getElementById(ul.config["imwrap_id"]));
+        new ResizeObserver(function() {
+            ul.handle_toolbox_overflow();
+        }).observe(document.getElementById(ul.config["container_id"]));
 
         // Buttons to change annotation mode
         jquery_default()(document).on("click", "a.md-btn", (e) => {
@@ -15249,6 +15257,8 @@ class ULabel {
             
             // Create listers to manipulate and export this object
             ULabel.create_listeners(that);
+
+            that.handle_toolbox_overflow();
             
             // Set the canvas elements in the correct stacking order given current subtask
             that.set_subtask(that.state["current_subtask"]);
@@ -15276,6 +15286,20 @@ class ULabel {
 
     version() {
         return ULabel.version();
+    }
+
+    handle_toolbox_overflow() {
+        let tabs_height = jquery_default()("#"+this.config["container_id"] + " div.toolbox-tabs").height();
+        jquery_default()("#"+this.config["container_id"] + " div.toolbox_inner_cls").css("height", `calc(100% - ${tabs_height+38}px)`);
+        let view_height = jquery_default()("#"+this.config["container_id"] + " div.toolbox_cls")[0].scrollHeight - 38 - tabs_height;
+        let want_height = jquery_default()("#"+this.config["container_id"] + " div.toolbox_inner_cls")[0].scrollHeight;
+        console.log(view_height, want_height);
+        if (want_height <= view_height) {
+            jquery_default()("#"+this.config["container_id"] + " div.toolbox_inner_cls").css("overflow-y", "hidden");
+        }
+        else {
+            jquery_default()("#"+this.config["container_id"] + " div.toolbox_inner_cls").css("overflow-y", "scroll");
+        }
     }
 
     // A ratio of viewport height to image height

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -14722,7 +14722,7 @@ class ULabel {
         })
 
         // Keyboard only events
-        document.body.onkeydown = function(keypress_event) {
+        jquery_default()(document).on("keypress", (keypress_event) => {
             const shift = keypress_event.shiftKey;
             const ctrl = keypress_event.ctrlKey;
             let fms = ul.config["image_data"].frames.length > 1;
@@ -14792,7 +14792,7 @@ class ULabel {
             else {
                 // console.log(keypress_event);
             }
-        };
+        });
 
         window.addEventListener("beforeunload", function (e) {
             var confirmationMessage = '';
@@ -18391,6 +18391,35 @@ class ULabel {
         annbox.css("background-color", new_bg_color);
         return ret
     }
+
+    // Allow for external access and modification of annotations within a subtask
+    get_annotations(subtask) {
+        let ret = [];
+        for (let i = 0; i < this.subtasks[subtask]["annotations"]["ordering"].length; i++) {
+            let id = this.subtasks[subtask]["annotations"]["ordering"][i];
+            ret.push(this.subtasks[subtask]["annotations"]["access"][id]);
+        }
+        return JSON.parse(JSON.stringify(ret));
+    }
+    set_annotations(new_annotations, subtask) {
+        // Undo/redo won't work through a get/set
+        this.subtasks[subtask]["actions"]["stream"] = [];
+        this.subtasks[subtask]["actions"]["undo_stack"] = [];
+        let newanns = JSON.parse(JSON.stringify(new_annotations));
+        let new_ordering = [];
+        let new_access = {};
+        for (let i = 0; i < newanns.length; i++) {
+            new_ordering.push(newanns[i]["id"]);
+            new_access[newanns[i]["id"]] = newanns[i];
+        }
+        this.subtasks[subtask]["annotations"]["ordering"] = new_ordering;
+        this.subtasks[subtask]["annotations"]["access"] = new_access;
+        for (let i = 0; i < new_ordering.length; i++) {
+            this.rebuild_containing_box(new_ordering[i], false, subtask);
+        }
+        this.redraw_all_annotations(subtask);
+    }
+
 
     // Change frame
 

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -15293,7 +15293,6 @@ class ULabel {
         jquery_default()("#"+this.config["container_id"] + " div.toolbox_inner_cls").css("height", `calc(100% - ${tabs_height+38}px)`);
         let view_height = jquery_default()("#"+this.config["container_id"] + " div.toolbox_cls")[0].scrollHeight - 38 - tabs_height;
         let want_height = jquery_default()("#"+this.config["container_id"] + " div.toolbox_inner_cls")[0].scrollHeight;
-        console.log(view_height, want_height);
         if (want_height <= view_height) {
             jquery_default()("#"+this.config["container_id"] + " div.toolbox_inner_cls").css("overflow-y", "hidden");
         }
@@ -18416,17 +18415,73 @@ class ULabel {
         return ret
     }
 
+
+    reset_interaction_state(subtask=null) {
+        let q = [];
+        if (subtask == null) {
+            for (let st in this.subtasks) {
+                q.push(st);
+            }
+        }
+        else {
+            q.push(subtask);
+        }
+        for (let i = 0; i < q.length; i++) {
+            if (this.subtasks[q[i]]["state"]["active_id"] != null) {
+                // Delete polygon ender if exists
+                jquery_default()("#ender_" + this.subtasks[q[i]]["state"]["active_id"]).remove();
+            }
+            this.subtasks[q[i]]["state"]["is_in_edit"] = false;
+            this.subtasks[q[i]]["state"]["is_in_move"] = false;
+            this.subtasks[q[i]]["state"]["is_in_progress"] = false;
+            this.subtasks[q[i]]["state"]["active_id"] = null;
+            this.show
+        }
+        this.drag_state = {
+            "active_key": null,
+            "release_button": null,
+            "annotation": {
+                "mouse_start": null, // Screen coordinates where the current mouse drag started
+                "offset_start": null, // Scroll values where the current mouse drag started
+                "zoom_val_start": null // zoom_val when the dragging interaction started
+            },
+            "edit": {
+                "mouse_start": null, // Screen coordinates where the current mouse drag started
+                "offset_start": null, // Scroll values where the current mouse drag started
+                "zoom_val_start": null // zoom_val when the dragging interaction started
+            },
+            "pan": {
+                "mouse_start": null, // Screen coordinates where the current mouse drag started
+                "offset_start": null, // Scroll values where the current mouse drag started
+                "zoom_val_start": null // zoom_val when the dragging interaction started
+            },
+            "zoom": {
+                "mouse_start": null, // Screen coordinates where the current mouse drag started
+                "offset_start": null, // Scroll values where the current mouse drag started
+                "zoom_val_start": null // zoom_val when the dragging interaction started
+            },
+            "move": {
+                "mouse_start": null, // Screen coordinates where the current mouse drag started
+                "offset_start": null, // Scroll values where the current mouse drag started
+                "zoom_val_start": null // zoom_val when the dragging interaction started
+            }
+        };
+    }
+
     // Allow for external access and modification of annotations within a subtask
     get_annotations(subtask) {
         let ret = [];
         for (let i = 0; i < this.subtasks[subtask]["annotations"]["ordering"].length; i++) {
             let id = this.subtasks[subtask]["annotations"]["ordering"][i];
-            ret.push(this.subtasks[subtask]["annotations"]["access"][id]);
+            if (id != this.subtasks[this.state["current_subtask"]]["state"]["active_id"]) {
+                ret.push(this.subtasks[subtask]["annotations"]["access"][id]);
+            }
         }
         return JSON.parse(JSON.stringify(ret));
     }
     set_annotations(new_annotations, subtask) {
         // Undo/redo won't work through a get/set
+        this.reset_interaction_state();
         this.subtasks[subtask]["actions"]["stream"] = [];
         this.subtasks[subtask]["actions"]["undo_stack"] = [];
         let newanns = JSON.parse(JSON.stringify(new_annotations));

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,9 +36,9 @@
       "dev": true
     },
     "node_modules/@babel/highlight": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.8.tgz",
-      "integrity": "sha512-4vrIhfJyfNf+lCtXC2ck1rKSzDwciqF7IWFhXXrSOUC2O5DrVp+w4c6ed4AllTxhTkUP5x2tYj41VaxdVMMRDw==",
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+      "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.12.11",
@@ -205,9 +205,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.14.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.32.tgz",
-      "integrity": "sha512-/Ctrftx/zp4m8JOujM5ZhwzlWLx22nbQJiVqz8/zE15gOeEW+uly3FSX4fGFpcfEvFzXcMCJwq9lGVWgyARXhg==",
+      "version": "14.14.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.33.tgz",
+      "integrity": "sha512-oJqcTrgPUF29oUP8AsUqbXGJNuPutsetaa9kTQAQce5Lx5dTYWV02ScBiT/k1BX/Z7pKeqedmvp39Wu4zR7N7g==",
       "dev": true
     },
     "node_modules/@types/uuid": {
@@ -216,13 +216,13 @@
       "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.16.1.tgz",
-      "integrity": "sha512-SK777klBdlkUZpZLC1mPvyOWk9yAFCWmug13eAjVQ4/Q1LATE/NbcQL1xDHkptQkZOLnPmLUA1Y54m8dqYwnoQ==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.17.0.tgz",
+      "integrity": "sha512-/fKFDcoHg8oNan39IKFOb5WmV7oWhQe1K6CDaAVfJaNWEhmfqlA24g+u1lqU5bMH7zuNasfMId4LaYWC5ijRLw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "4.16.1",
-        "@typescript-eslint/scope-manager": "4.16.1",
+        "@typescript-eslint/experimental-utils": "4.17.0",
+        "@typescript-eslint/scope-manager": "4.17.0",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "lodash": "^4.17.15",
@@ -248,15 +248,15 @@
       }
     },
     "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.16.1.tgz",
-      "integrity": "sha512-0Hm3LSlMYFK17jO4iY3un1Ve9x1zLNn4EM50Lia+0EV99NdbK+cn0er7HC7IvBA23mBg3P+8dUkMXy4leL33UQ==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.17.0.tgz",
+      "integrity": "sha512-ZR2NIUbnIBj+LGqCFGQ9yk2EBQrpVVFOh9/Kd0Lm6gLpSAcCuLLe5lUCibKGCqyH9HPwYC0GIJce2O1i8VYmWA==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.16.1",
-        "@typescript-eslint/types": "4.16.1",
-        "@typescript-eslint/typescript-estree": "4.16.1",
+        "@typescript-eslint/scope-manager": "4.17.0",
+        "@typescript-eslint/types": "4.17.0",
+        "@typescript-eslint/typescript-estree": "4.17.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       },
@@ -272,14 +272,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.16.1.tgz",
-      "integrity": "sha512-/c0LEZcDL5y8RyI1zLcmZMvJrsR6SM1uetskFkoh3dvqDKVXPsXI+wFB/CbVw7WkEyyTKobC1mUNp/5y6gRvXg==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.17.0.tgz",
+      "integrity": "sha512-KYdksiZQ0N1t+6qpnl6JeK9ycCFprS9xBAiIrw4gSphqONt8wydBw4BXJi3C11ywZmyHulvMaLjWsxDjUSDwAw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "4.16.1",
-        "@typescript-eslint/types": "4.16.1",
-        "@typescript-eslint/typescript-estree": "4.16.1",
+        "@typescript-eslint/scope-manager": "4.17.0",
+        "@typescript-eslint/types": "4.17.0",
+        "@typescript-eslint/typescript-estree": "4.17.0",
         "debug": "^4.1.1"
       },
       "engines": {
@@ -299,13 +299,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.16.1.tgz",
-      "integrity": "sha512-6IlZv9JaurqV0jkEg923cV49aAn8V6+1H1DRfhRcvZUrptQ+UtSKHb5kwTayzOYTJJ/RsYZdcvhOEKiBLyc0Cw==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.17.0.tgz",
+      "integrity": "sha512-OJ+CeTliuW+UZ9qgULrnGpPQ1bhrZNFpfT/Bc0pzNeyZwMik7/ykJ0JHnQ7krHanFN9wcnPK89pwn84cRUmYjw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.16.1",
-        "@typescript-eslint/visitor-keys": "4.16.1"
+        "@typescript-eslint/types": "4.17.0",
+        "@typescript-eslint/visitor-keys": "4.17.0"
       },
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -316,9 +316,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.16.1.tgz",
-      "integrity": "sha512-nnKqBwMgRlhzmJQF8tnFDZWfunXmJyuXj55xc8Kbfup4PbkzdoDXZvzN8//EiKR27J6vUSU8j4t37yUuYPiLqA==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.17.0.tgz",
+      "integrity": "sha512-RN5z8qYpJ+kXwnLlyzZkiJwfW2AY458Bf8WqllkondQIcN2ZxQowAToGSd9BlAUZDB5Ea8I6mqL2quGYCLT+2g==",
       "dev": true,
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -329,13 +329,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.16.1.tgz",
-      "integrity": "sha512-m8I/DKHa8YbeHt31T+UGd/l8Kwr0XCTCZL3H4HMvvLCT7HU9V7yYdinTOv1gf/zfqNeDcCgaFH2BMsS8x6NvJg==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.17.0.tgz",
+      "integrity": "sha512-lRhSFIZKUEPPWpWfwuZBH9trYIEJSI0vYsrxbvVvNyIUDoKWaklOAelsSkeh3E2VBSZiNe9BZ4E5tYBZbUczVQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.16.1",
-        "@typescript-eslint/visitor-keys": "4.16.1",
+        "@typescript-eslint/types": "4.17.0",
+        "@typescript-eslint/visitor-keys": "4.17.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-glob": "^4.0.1",
@@ -356,12 +356,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.16.1.tgz",
-      "integrity": "sha512-s/aIP1XcMkEqCNcPQtl60ogUYjSM8FU2mq1O7y5cFf3Xcob1z1iXWNB6cC43Op+NGRTFgGolri6s8z/efA9i1w==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.17.0.tgz",
+      "integrity": "sha512-WfuMN8mm5SSqXuAr9NM+fItJ0SVVphobWYkWOwQ1odsfC014Vdxk/92t4JwS1Q6fCA/ABfCKpa3AVtpUKTNKGQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.16.1",
+        "@typescript-eslint/types": "4.17.0",
         "eslint-visitor-keys": "^2.0.0"
       },
       "engines": {
@@ -797,9 +797,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001197",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001197.tgz",
-      "integrity": "sha512-8aE+sqBqtXz4G8g35Eg/XEaFr2N7rd/VQ6eABGBmNtcB8cN6qNJhMi6oSFy4UWWZgqgL3filHT8Nha4meu3tsw==",
+      "version": "1.0.30001198",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001198.tgz",
+      "integrity": "sha512-r5GGgESqOPZzwvdLVER374FpQu2WluCF1Z2DSiFJ89KSmGjT0LVKjgv4NcAqHmGWF9ihNpqRI9KXO9Ex4sKsgA==",
       "dev": true
     },
     "node_modules/chalk": {
@@ -992,9 +992,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.682",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.682.tgz",
-      "integrity": "sha512-zok2y37qR00U14uM6qBz/3iIjWHom2eRfC2S1StA0RslP7x34jX+j4mxv80t8OEOHLJPVG54ZPeaFxEI7gPrwg==",
+      "version": "1.3.684",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.684.tgz",
+      "integrity": "sha512-GV/vz2EmmtRSvfGSQ5A0Lucic//IRSDijgL15IgzbBEEnp4rfbxeUSZSlBfmsj7BQvE4sBdgfsvPzLCnp6L21w==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -3202,9 +3202,9 @@
       }
     },
     "node_modules/webpack/node_modules/acorn": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.5.tgz",
-      "integrity": "sha512-v+DieK/HJkJOpFBETDJioequtc3PfxsWMaxIdIwujtF7FEV/MAyDQLlm6/zPvr7Mix07mLh6ccVwIsloceodlg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.0.tgz",
+      "integrity": "sha512-LWCF/Wn0nfHOmJ9rzQApGnxnvgfROzGilS8936rqN/lfcYkY9MYZzdMqN+2NJ4SlTc+m5HiSa+kNfDtI64dwUA==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -3285,9 +3285,9 @@
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.8.tgz",
-      "integrity": "sha512-4vrIhfJyfNf+lCtXC2ck1rKSzDwciqF7IWFhXXrSOUC2O5DrVp+w4c6ed4AllTxhTkUP5x2tYj41VaxdVMMRDw==",
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+      "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.12.11",
@@ -3429,9 +3429,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.32.tgz",
-      "integrity": "sha512-/Ctrftx/zp4m8JOujM5ZhwzlWLx22nbQJiVqz8/zE15gOeEW+uly3FSX4fGFpcfEvFzXcMCJwq9lGVWgyARXhg==",
+      "version": "14.14.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.33.tgz",
+      "integrity": "sha512-oJqcTrgPUF29oUP8AsUqbXGJNuPutsetaa9kTQAQce5Lx5dTYWV02ScBiT/k1BX/Z7pKeqedmvp39Wu4zR7N7g==",
       "dev": true
     },
     "@types/uuid": {
@@ -3440,13 +3440,13 @@
       "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ=="
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.16.1.tgz",
-      "integrity": "sha512-SK777klBdlkUZpZLC1mPvyOWk9yAFCWmug13eAjVQ4/Q1LATE/NbcQL1xDHkptQkZOLnPmLUA1Y54m8dqYwnoQ==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.17.0.tgz",
+      "integrity": "sha512-/fKFDcoHg8oNan39IKFOb5WmV7oWhQe1K6CDaAVfJaNWEhmfqlA24g+u1lqU5bMH7zuNasfMId4LaYWC5ijRLw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.16.1",
-        "@typescript-eslint/scope-manager": "4.16.1",
+        "@typescript-eslint/experimental-utils": "4.17.0",
+        "@typescript-eslint/scope-manager": "4.17.0",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "lodash": "^4.17.15",
@@ -3456,55 +3456,55 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.16.1.tgz",
-      "integrity": "sha512-0Hm3LSlMYFK17jO4iY3un1Ve9x1zLNn4EM50Lia+0EV99NdbK+cn0er7HC7IvBA23mBg3P+8dUkMXy4leL33UQ==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.17.0.tgz",
+      "integrity": "sha512-ZR2NIUbnIBj+LGqCFGQ9yk2EBQrpVVFOh9/Kd0Lm6gLpSAcCuLLe5lUCibKGCqyH9HPwYC0GIJce2O1i8VYmWA==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.16.1",
-        "@typescript-eslint/types": "4.16.1",
-        "@typescript-eslint/typescript-estree": "4.16.1",
+        "@typescript-eslint/scope-manager": "4.17.0",
+        "@typescript-eslint/types": "4.17.0",
+        "@typescript-eslint/typescript-estree": "4.17.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.16.1.tgz",
-      "integrity": "sha512-/c0LEZcDL5y8RyI1zLcmZMvJrsR6SM1uetskFkoh3dvqDKVXPsXI+wFB/CbVw7WkEyyTKobC1mUNp/5y6gRvXg==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.17.0.tgz",
+      "integrity": "sha512-KYdksiZQ0N1t+6qpnl6JeK9ycCFprS9xBAiIrw4gSphqONt8wydBw4BXJi3C11ywZmyHulvMaLjWsxDjUSDwAw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.16.1",
-        "@typescript-eslint/types": "4.16.1",
-        "@typescript-eslint/typescript-estree": "4.16.1",
+        "@typescript-eslint/scope-manager": "4.17.0",
+        "@typescript-eslint/types": "4.17.0",
+        "@typescript-eslint/typescript-estree": "4.17.0",
         "debug": "^4.1.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.16.1.tgz",
-      "integrity": "sha512-6IlZv9JaurqV0jkEg923cV49aAn8V6+1H1DRfhRcvZUrptQ+UtSKHb5kwTayzOYTJJ/RsYZdcvhOEKiBLyc0Cw==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.17.0.tgz",
+      "integrity": "sha512-OJ+CeTliuW+UZ9qgULrnGpPQ1bhrZNFpfT/Bc0pzNeyZwMik7/ykJ0JHnQ7krHanFN9wcnPK89pwn84cRUmYjw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.16.1",
-        "@typescript-eslint/visitor-keys": "4.16.1"
+        "@typescript-eslint/types": "4.17.0",
+        "@typescript-eslint/visitor-keys": "4.17.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.16.1.tgz",
-      "integrity": "sha512-nnKqBwMgRlhzmJQF8tnFDZWfunXmJyuXj55xc8Kbfup4PbkzdoDXZvzN8//EiKR27J6vUSU8j4t37yUuYPiLqA==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.17.0.tgz",
+      "integrity": "sha512-RN5z8qYpJ+kXwnLlyzZkiJwfW2AY458Bf8WqllkondQIcN2ZxQowAToGSd9BlAUZDB5Ea8I6mqL2quGYCLT+2g==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.16.1.tgz",
-      "integrity": "sha512-m8I/DKHa8YbeHt31T+UGd/l8Kwr0XCTCZL3H4HMvvLCT7HU9V7yYdinTOv1gf/zfqNeDcCgaFH2BMsS8x6NvJg==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.17.0.tgz",
+      "integrity": "sha512-lRhSFIZKUEPPWpWfwuZBH9trYIEJSI0vYsrxbvVvNyIUDoKWaklOAelsSkeh3E2VBSZiNe9BZ4E5tYBZbUczVQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.16.1",
-        "@typescript-eslint/visitor-keys": "4.16.1",
+        "@typescript-eslint/types": "4.17.0",
+        "@typescript-eslint/visitor-keys": "4.17.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-glob": "^4.0.1",
@@ -3513,12 +3513,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.16.1.tgz",
-      "integrity": "sha512-s/aIP1XcMkEqCNcPQtl60ogUYjSM8FU2mq1O7y5cFf3Xcob1z1iXWNB6cC43Op+NGRTFgGolri6s8z/efA9i1w==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.17.0.tgz",
+      "integrity": "sha512-WfuMN8mm5SSqXuAr9NM+fItJ0SVVphobWYkWOwQ1odsfC014Vdxk/92t4JwS1Q6fCA/ABfCKpa3AVtpUKTNKGQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.16.1",
+        "@typescript-eslint/types": "4.17.0",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -3879,9 +3879,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001197",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001197.tgz",
-      "integrity": "sha512-8aE+sqBqtXz4G8g35Eg/XEaFr2N7rd/VQ6eABGBmNtcB8cN6qNJhMi6oSFy4UWWZgqgL3filHT8Nha4meu3tsw==",
+      "version": "1.0.30001198",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001198.tgz",
+      "integrity": "sha512-r5GGgESqOPZzwvdLVER374FpQu2WluCF1Z2DSiFJ89KSmGjT0LVKjgv4NcAqHmGWF9ihNpqRI9KXO9Ex4sKsgA==",
       "dev": true
     },
     "chalk": {
@@ -4030,9 +4030,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.682",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.682.tgz",
-      "integrity": "sha512-zok2y37qR00U14uM6qBz/3iIjWHom2eRfC2S1StA0RslP7x34jX+j4mxv80t8OEOHLJPVG54ZPeaFxEI7gPrwg==",
+      "version": "1.3.684",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.684.tgz",
+      "integrity": "sha512-GV/vz2EmmtRSvfGSQ5A0Lucic//IRSDijgL15IgzbBEEnp4rfbxeUSZSlBfmsj7BQvE4sBdgfsvPzLCnp6L21w==",
       "dev": true
     },
     "emoji-regex": {
@@ -5630,9 +5630,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "8.0.5",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.5.tgz",
-          "integrity": "sha512-v+DieK/HJkJOpFBETDJioequtc3PfxsWMaxIdIwujtF7FEV/MAyDQLlm6/zPvr7Mix07mLh6ccVwIsloceodlg==",
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.0.tgz",
+          "integrity": "sha512-LWCF/Wn0nfHOmJ9rzQApGnxnvgfROzGilS8936rqN/lfcYkY9MYZzdMqN+2NJ4SlTc+m5HiSa+kNfDtI64dwUA==",
           "dev": true
         }
       }

--- a/src/blobs.js
+++ b/src/blobs.js
@@ -1685,6 +1685,11 @@ div#${prntid} div.dialogs_container {
    left: 0;
 }
 
+div.toolbox_inner_cls {
+   height: calc(100% - 38px);
+   overflow-y: scroll;
+}
+
 /* ========== Tab Buttons ========== */
 
 div#${prntid} div.toolbox-tabs {
@@ -1895,20 +1900,20 @@ div#${prntid}.ulabel-night div.night-status {
 }
 
 
-div#${prntid}.ulabel-night div.annbox_cls::-webkit-scrollbar {
+div#${prntid}.ulabel-night *::-webkit-scrollbar {
    background-color: black;
 }
-div#${prntid}.ulabel-night div.annbox_cls::-webkit-scrollbar-track {
+div#${prntid}.ulabel-night *::-webkit-scrollbar-track {
    background-color: black;
 }
-div#${prntid}.ulabel-night div.annbox_cls::-webkit-scrollbar-thumb {
+div#${prntid}.ulabel-night *::-webkit-scrollbar-thumb {
    border: 1px solid rgb(110, 110, 110);
    background-color: rgb(51, 51, 51);
 }
-div#${prntid}.ulabel-night div.annbox_cls::-webkit-scrollbar-thumb:hover {
+div#${prntid}.ulabel-night *::-webkit-scrollbar-thumb:hover {
    background-color: rgb(90, 90, 90);
 } 
-div#${prntid}.ulabel-night div.annbox_cls::-webkit-scrollbar-corner {
+div#${prntid}.ulabel-night *::-webkit-scrollbar-corner {
    background-color:rgb(0, 60, 95);
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -899,6 +899,9 @@ class ULabel {
         new ResizeObserver(function() {
             ul.reposition_dialogs();
         }).observe(document.getElementById(ul.config["imwrap_id"]));
+        new ResizeObserver(function() {
+            ul.handle_toolbox_overflow();
+        }).observe(document.getElementById(ul.config["container_id"]));
 
         // Buttons to change annotation mode
         $(document).on("click", "a.md-btn", (e) => {
@@ -1627,6 +1630,8 @@ class ULabel {
             
             // Create listers to manipulate and export this object
             ULabel.create_listeners(that);
+
+            that.handle_toolbox_overflow();
             
             // Set the canvas elements in the correct stacking order given current subtask
             that.set_subtask(that.state["current_subtask"]);
@@ -1654,6 +1659,20 @@ class ULabel {
 
     version() {
         return ULabel.version();
+    }
+
+    handle_toolbox_overflow() {
+        let tabs_height = $("#"+this.config["container_id"] + " div.toolbox-tabs").height();
+        $("#"+this.config["container_id"] + " div.toolbox_inner_cls").css("height", `calc(100% - ${tabs_height+38}px)`);
+        let view_height = $("#"+this.config["container_id"] + " div.toolbox_cls")[0].scrollHeight - 38 - tabs_height;
+        let want_height = $("#"+this.config["container_id"] + " div.toolbox_inner_cls")[0].scrollHeight;
+        console.log(view_height, want_height);
+        if (want_height <= view_height) {
+            $("#"+this.config["container_id"] + " div.toolbox_inner_cls").css("overflow-y", "hidden");
+        }
+        else {
+            $("#"+this.config["container_id"] + " div.toolbox_inner_cls").css("overflow-y", "scroll");
+        }
     }
 
     // A ratio of viewport height to image height

--- a/src/index.js
+++ b/src/index.js
@@ -1666,7 +1666,6 @@ class ULabel {
         $("#"+this.config["container_id"] + " div.toolbox_inner_cls").css("height", `calc(100% - ${tabs_height+38}px)`);
         let view_height = $("#"+this.config["container_id"] + " div.toolbox_cls")[0].scrollHeight - 38 - tabs_height;
         let want_height = $("#"+this.config["container_id"] + " div.toolbox_inner_cls")[0].scrollHeight;
-        console.log(view_height, want_height);
         if (want_height <= view_height) {
             $("#"+this.config["container_id"] + " div.toolbox_inner_cls").css("overflow-y", "hidden");
         }
@@ -4789,17 +4788,73 @@ class ULabel {
         return ret
     }
 
+
+    reset_interaction_state(subtask=null) {
+        let q = [];
+        if (subtask == null) {
+            for (let st in this.subtasks) {
+                q.push(st);
+            }
+        }
+        else {
+            q.push(subtask);
+        }
+        for (let i = 0; i < q.length; i++) {
+            if (this.subtasks[q[i]]["state"]["active_id"] != null) {
+                // Delete polygon ender if exists
+                $("#ender_" + this.subtasks[q[i]]["state"]["active_id"]).remove();
+            }
+            this.subtasks[q[i]]["state"]["is_in_edit"] = false;
+            this.subtasks[q[i]]["state"]["is_in_move"] = false;
+            this.subtasks[q[i]]["state"]["is_in_progress"] = false;
+            this.subtasks[q[i]]["state"]["active_id"] = null;
+            this.show
+        }
+        this.drag_state = {
+            "active_key": null,
+            "release_button": null,
+            "annotation": {
+                "mouse_start": null, // Screen coordinates where the current mouse drag started
+                "offset_start": null, // Scroll values where the current mouse drag started
+                "zoom_val_start": null // zoom_val when the dragging interaction started
+            },
+            "edit": {
+                "mouse_start": null, // Screen coordinates where the current mouse drag started
+                "offset_start": null, // Scroll values where the current mouse drag started
+                "zoom_val_start": null // zoom_val when the dragging interaction started
+            },
+            "pan": {
+                "mouse_start": null, // Screen coordinates where the current mouse drag started
+                "offset_start": null, // Scroll values where the current mouse drag started
+                "zoom_val_start": null // zoom_val when the dragging interaction started
+            },
+            "zoom": {
+                "mouse_start": null, // Screen coordinates where the current mouse drag started
+                "offset_start": null, // Scroll values where the current mouse drag started
+                "zoom_val_start": null // zoom_val when the dragging interaction started
+            },
+            "move": {
+                "mouse_start": null, // Screen coordinates where the current mouse drag started
+                "offset_start": null, // Scroll values where the current mouse drag started
+                "zoom_val_start": null // zoom_val when the dragging interaction started
+            }
+        };
+    }
+
     // Allow for external access and modification of annotations within a subtask
     get_annotations(subtask) {
         let ret = [];
         for (let i = 0; i < this.subtasks[subtask]["annotations"]["ordering"].length; i++) {
             let id = this.subtasks[subtask]["annotations"]["ordering"][i];
-            ret.push(this.subtasks[subtask]["annotations"]["access"][id]);
+            if (id != this.subtasks[this.state["current_subtask"]]["state"]["active_id"]) {
+                ret.push(this.subtasks[subtask]["annotations"]["access"][id]);
+            }
         }
         return JSON.parse(JSON.stringify(ret));
     }
     set_annotations(new_annotations, subtask) {
         // Undo/redo won't work through a get/set
+        this.reset_interaction_state();
         this.subtasks[subtask]["actions"]["stream"] = [];
         this.subtasks[subtask]["actions"]["undo_stack"] = [];
         let newanns = JSON.parse(JSON.stringify(new_annotations));

--- a/src/index.js
+++ b/src/index.js
@@ -1100,7 +1100,7 @@ class ULabel {
         })
 
         // Keyboard only events
-        document.body.onkeydown = function(keypress_event) {
+        $(document).on("keypress", (keypress_event) => {
             const shift = keypress_event.shiftKey;
             const ctrl = keypress_event.ctrlKey;
             let fms = ul.config["image_data"].frames.length > 1;
@@ -1170,7 +1170,7 @@ class ULabel {
             else {
                 // console.log(keypress_event);
             }
-        };
+        });
 
         window.addEventListener("beforeunload", function (e) {
             var confirmationMessage = '';
@@ -4769,6 +4769,35 @@ class ULabel {
         annbox.css("background-color", new_bg_color);
         return ret
     }
+
+    // Allow for external access and modification of annotations within a subtask
+    get_annotations(subtask) {
+        let ret = [];
+        for (let i = 0; i < this.subtasks[subtask]["annotations"]["ordering"].length; i++) {
+            let id = this.subtasks[subtask]["annotations"]["ordering"][i];
+            ret.push(this.subtasks[subtask]["annotations"]["access"][id]);
+        }
+        return JSON.parse(JSON.stringify(ret));
+    }
+    set_annotations(new_annotations, subtask) {
+        // Undo/redo won't work through a get/set
+        this.subtasks[subtask]["actions"]["stream"] = [];
+        this.subtasks[subtask]["actions"]["undo_stack"] = [];
+        let newanns = JSON.parse(JSON.stringify(new_annotations));
+        let new_ordering = [];
+        let new_access = {};
+        for (let i = 0; i < newanns.length; i++) {
+            new_ordering.push(newanns[i]["id"]);
+            new_access[newanns[i]["id"]] = newanns[i];
+        }
+        this.subtasks[subtask]["annotations"]["ordering"] = new_ordering;
+        this.subtasks[subtask]["annotations"]["access"] = new_access;
+        for (let i = 0; i < new_ordering.length; i++) {
+            this.rebuild_containing_box(new_ordering[i], false, subtask);
+        }
+        this.redraw_all_annotations(subtask);
+    }
+
 
     // Change frame
 


### PR DESCRIPTION
# Added Getter and Setter

## Description

See `demo/getset.html` for an example.

### `get_annotations(subtask)`

*(string) => array* -- Gets the current list of annotations within the provided subtask.

### `set_annotations(new_annotations, subtask)`

*(array, string) => void* -- Sets the annotations for the provided subtask.

## PR Checklist

- [x] Merged latest master
- [x] Version number in `package.json` has been bumped since last release
- [x] Version numbers match between package `package.json` and `src/version.js`
- [x] Ran `npm install` and `npm run build` AFTER bumping the version number
- [x] Updated documentation if necessary (currently just in `api_spec.md`)
- [x] Added changes to `changelog.md`

## Breaking API Changes

None, but note that undo/redo stacks are reset after `set_annotations` is called.
