### PR TITLE
Instructions

### DIFF
--- a/api_spec.md
+++ b/api_spec.md
@@ -32,6 +32,7 @@ class ULabel(
     px_per_px=1,           // number
     init_crop=null         // object
     initial_line_size=4    // number
+    instructions_url=null  // string
 )
 ```
 
@@ -62,6 +63,10 @@ Objects must be provided in the form of
     name: "<Arbitrary Button Name>",
     hook: (annotations) => {
         // Define submit behavior here
+
+        // ULabel instance is bound to this function, and so it can be accessed with this
+
+        // If behavior is to leave this page, use this.set_saved(true) to avoid warning to user
 
         // If submit is unsuccessful and annotations edits should not be treated as "saved", return false
     }
@@ -247,6 +252,10 @@ In some cases, you may want the annotations to render at a higher or lower resol
 
 The line width with which new annotations are drawn initially. Units are pixels in the underlying image.
 
+### `instructions_url`
+
+URL to a page that gives annotation instructions.
+
 ## Display Utility Functions
 
 Display utilities are provided for a constructed `ULabel` object.
@@ -266,6 +275,10 @@ Display utilities are provided for a constructed `ULabel` object.
 ### `set_annotations(new_annotations, subtask)`
 
 *(array, string) => void* -- Sets the annotations for the provided subtask.
+
+### `set_saved(saved)`
+
+*(bool) => void* -- Allows js script implementing the ULabel class to set saved status, e.g., during callback.
 
 ## Generic Callbacks
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,10 @@ All notable changes to this project will be documented here.
 
 ## [unreleased]
 
-<nothing_yet>
+- Added the `point` annotation mode
+- Added support for a link to instructions
+- Added a `set_saved()` function so page can unload without warning
+- Bound ulabel instance to submit callback so above function can be easily called
 
 ## [0.4.7] - March 11, 2021
 

--- a/demo/frames.html
+++ b/demo/frames.html
@@ -49,7 +49,7 @@
                                 "id": 12
                             },
                         ],
-                        "allowed_modes": ["bbox", "polygon", "contour", "bbox3"],
+                        "allowed_modes": ["bbox", "point", "polygon", "contour", "bbox3"],
                         "resume_from": null,
                         "task_meta": null,
                         "annotation_meta": null,

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -11551,8 +11551,9 @@ function version(uuid) {
 /******/ 	// The require function
 /******/ 	function __webpack_require__(moduleId) {
 /******/ 		// Check if module is in cache
-/******/ 		if(__webpack_module_cache__[moduleId]) {
-/******/ 			return __webpack_module_cache__[moduleId].exports;
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
 /******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = __webpack_module_cache__[moduleId] = {
@@ -13635,7 +13636,7 @@ const COLORS = [
 
 
 ;// CONCATENATED MODULE: ./src/version.js
-const ULABEL_VERSION = "0.4.7";
+const ULABEL_VERSION = "0.4.8-dev";
 ;// CONCATENATED MODULE: ./src/index.js
 /*
 Uncertain Labeling Tool
@@ -15047,7 +15048,8 @@ class ULabel {
         annotation_meta=null,
         px_per_px=1,
         initial_crop=null,
-        initial_line_size=4
+        initial_line_size=4,
+        instructions_url=null
     ) {
         // Unroll safe default arguments
         if (task_meta == null) {task_meta = {};}
@@ -15102,6 +15104,7 @@ class ULabel {
             // Behavior on special interactions
             "done_callback": on_submit_unrolled.hook,
             "done_button": on_submit_unrolled.name,
+            "instructions_url": instructions_url,
 
             // ID Dialog config
             "cl_opacity": 0.4,

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -14711,7 +14711,7 @@ class ULabel {
                     );
                 }
             }
-            if (ul.config["done_callback"](submit_payload) !== false) {
+            if (ul.config["done_callback"].bind(ul)(submit_payload) !== false) {
                 ul.set_saved(true);
             }
         });

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -14712,8 +14712,7 @@ class ULabel {
                 }
             }
             if (ul.config["done_callback"](submit_payload) !== false) {
-                ul.state["edited"] = false;
-                jquery_default()("#"+ul.config["container_id"] + " a#submit-button").removeAttr("href");
+                ul.set_saved(true);
             }
         });
 
@@ -16593,9 +16592,18 @@ class ULabel {
 
     // Action Stream Events
 
+    set_saved(saved) {
+        if (saved) {
+            jquery_default()("#"+this.config["container_id"] + " a#submit-button").removeAttr("href");
+        }
+        else {
+            jquery_default()("#"+this.config["container_id"] + " a#submit-button").attr("href", "#");
+        }
+        this.state["edited"] = !saved;
+    }
+
     record_action(action, is_redo=false) {
-        jquery_default()("#"+this.config["container_id"] + " a#submit-button").attr("href", "#");
-        this.state["edited"] = true;
+        this.set_saved(false);
 
         // After a new action, you can no longer redo old actions
         if (!is_redo) {

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -13777,7 +13777,7 @@ const COLORS = [
 
 
 ;// CONCATENATED MODULE: ./src/version.js
-const ULABEL_VERSION = "0.4.8-dev";
+const ULABEL_VERSION = "0.4.8";
 ;// CONCATENATED MODULE: ./src/index.js
 /*
 Uncertain Labeling Tool
@@ -17227,7 +17227,6 @@ class ULabel {
             this.subtasks[subtask]["annotations"]["access"][actid]["containing_box"]["brx"] += 3*line_size;
             this.subtasks[subtask]["annotations"]["access"][actid]["containing_box"]["bry"] += 3*line_size;
         }
-        console.log(this.subtasks[subtask]["annotations"]["access"][actid]["containing_box"]);
         // TODO modification here for T-Bar would be nice too
     }
 

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -11715,6 +11715,147 @@ const BBOX_SVG = `
   </g>
 </svg>
 `;
+const POINT_SVG = `
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="100mm"
+   height="100mm"
+   viewBox="0 0 100 100"
+   version="1.1"
+   id="svg7244"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="point.svg">
+  <defs
+     id="defs7238">
+    <marker
+       inkscape:stockid="DotL"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="marker1156"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1154"
+         d="M -2.5,-1.0 C -2.5,1.7600000 -4.7400000,4.0 -7.5,4.0 C -10.260000,4.0 -12.5,1.7600000 -12.5,-1.0 C -12.5,-3.7600000 -10.260000,-6.0 -7.5,-6.0 C -4.7400000,-6.0 -2.5,-3.7600000 -2.5,-1.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) translate(7.4, 1)" />
+    </marker>
+    <marker
+       inkscape:stockid="DotL"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="marker1152"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1150"
+         d="M -2.5,-1.0 C -2.5,1.7600000 -4.7400000,4.0 -7.5,4.0 C -10.260000,4.0 -12.5,1.7600000 -12.5,-1.0 C -12.5,-3.7600000 -10.260000,-6.0 -7.5,-6.0 C -4.7400000,-6.0 -2.5,-3.7600000 -2.5,-1.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) translate(7.4, 1)" />
+    </marker>
+    <marker
+       inkscape:stockid="DotL"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="marker1148"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path946"
+         d="M -2.5,-1.0 C -2.5,1.7600000 -4.7400000,4.0 -7.5,4.0 C -10.260000,4.0 -12.5,1.7600000 -12.5,-1.0 C -12.5,-3.7600000 -10.260000,-6.0 -7.5,-6.0 C -4.7400000,-6.0 -2.5,-3.7600000 -2.5,-1.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) translate(7.4, 1)" />
+    </marker>
+    <marker
+       inkscape:stockid="DotL"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="DotL"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4587"
+         d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(0.8,0,0,0.8,5.92,0.8)" />
+    </marker>
+    <marker
+       inkscape:stockid="DotL"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7235"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7233"
+         d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(0.8,0,0,0.8,5.92,0.8)" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.1443229"
+     inkscape:cx="138.27833"
+     inkscape:cy="159.299"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1043"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7241">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-197)">
+    <circle
+       style="fill:#fedbdb;fill-opacity:0;stroke:#000000;stroke-width:3.34195209;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       id="path884"
+       cx="50"
+       cy="247"
+       r="23.329023" />
+    <circle
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1.06185877;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       id="path886"
+       cx="50"
+       cy="247"
+       r="6.9690704" />
+  </g>
+</svg>
+`;
 const POLYGON_SVG = `
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
@@ -14198,6 +14339,7 @@ class ULabel {
         let curmd = ul.subtasks[crst]["state"]["annotation_mode"];
         let md_buttons = [
             ULabel.get_md_button("bbox", "Bounding Box", BBOX_SVG, curmd, ul.subtasks),
+            ULabel.get_md_button("point", "Point", POINT_SVG, curmd, ul.subtasks),
             ULabel.get_md_button("polygon", "Polygon", POLYGON_SVG, curmd, ul.subtasks),
             ULabel.get_md_button("tbar", "T-Bar", TBAR_SVG, curmd, ul.subtasks),
             ULabel.get_md_button("polyline", "Polyline", POLYLINE_SVG, curmd, ul.subtasks),
@@ -15472,6 +15614,10 @@ class ULabel {
     // Get the start of a spatial payload based on mouse event and current annotation mode
     get_init_spatial(gmx, gmy, annotation_mode) {
         switch (annotation_mode) {
+            case "point":
+                return [
+                    [gmx, gmy]
+                ];
             case "bbox":
             case "polygon":
             case "contour":
@@ -15510,6 +15656,8 @@ class ULabel {
                 bbj = parseInt(access_str[1], 10);
                 bbox_pts = this.subtasks[this.state["current_subtask"]]["annotations"]["access"][annid]["spatial_payload"];
                 return [bbox_pts[bbi][0], bbox_pts[bbj][1]];
+            case "point":
+                return JSON.parse(JSON.stringify(this.subtasks[this.state["current_subtask"]]["annotations"]["access"][annid]["spatial_payload"]));
             case "bbox3":
                 // TODO(3d)
                 bbi = parseInt(access_str[0], 10);
@@ -15567,6 +15715,10 @@ class ULabel {
                 bbj = parseInt(access_str[1], 10);
                 this.subtasks[this.state["current_subtask"]]["annotations"]["access"][annid]["spatial_payload"][bbi][0] = val[0];
                 this.subtasks[this.state["current_subtask"]]["annotations"]["access"][annid]["spatial_payload"][bbj][1] = val[1];
+                break;
+            case "point":
+                this.subtasks[this.state["current_subtask"]]["annotations"]["access"][annid]["spatial_payload"][bbi][0] = val[0];
+                this.subtasks[this.state["current_subtask"]]["annotations"]["access"][annid]["spatial_payload"][bbi][0] = val[0];
                 break;
             case "bbox3":
                 bbi = parseInt(access_str[0], 10);
@@ -15706,6 +15858,45 @@ class ULabel {
         ctx.lineTo((ep[0] + diffX)*px_per_px, (ep[1] + diffY)*px_per_px);
         ctx.lineTo((ep[0] + diffX)*px_per_px, (sp[1] + diffY)*px_per_px);
         ctx.lineTo((sp[0] + diffX)*px_per_px, (sp[1] + diffY)*px_per_px);
+        ctx.closePath();
+        ctx.stroke();
+    }
+
+    draw_point(annotation_object, ctx, demo=false, offset=null, subtask=null) {
+        const px_per_px = this.config["px_per_px"];
+        let diffX = 0;
+        let diffY = 0;
+        if (offset != null) {
+            diffX = offset["diffX"];
+            diffY = offset["diffY"];
+        }
+
+        let line_size = null;
+        if ("line_size" in annotation_object) {
+            line_size = annotation_object["line_size"];
+        }
+        else {
+            line_size = this.get_line_size(demo);
+        }
+    
+        // Prep for bbox drawing
+        let color = this.get_annotation_color(annotation_object["classification_payloads"], false, subtask);
+        ctx.fillStyle = color;
+        ctx.strokeStyle = color;
+        ctx.lineJoin = "round";
+        ctx.lineWidth = line_size*px_per_px;
+        ctx.imageSmoothingEnabled = false;
+        ctx.globalCompositeOperation = "source-over";
+    
+        // Draw the box
+        const sp = annotation_object["spatial_payload"][0];
+        ctx.beginPath();
+        ctx.arc((sp[0] + diffX)*px_per_px, (sp[1] + diffY)*px_per_px, line_size*px_per_px*0.75, 0, 2*Math.PI);
+        ctx.closePath();
+        ctx.stroke();
+        ctx.fill();
+        ctx.beginPath();
+        ctx.arc((sp[0] + diffX)*px_per_px, (sp[1] + diffY)*px_per_px, line_size*px_per_px*3, 0, 2*Math.PI);
         ctx.closePath();
         ctx.stroke();
     }
@@ -15992,6 +16183,9 @@ class ULabel {
         switch (annotation_object["spatial_type"]) {
             case "bbox":
                 this.draw_bounding_box(annotation_object, ctx, demo, offset, subtask);
+                break;
+            case "point":
+                this.draw_point(annotation_object, ctx, demo, offset, subtask);
                 break;
             case "bbox3":
                 // TODO(new3d)
@@ -16518,9 +16712,10 @@ class ULabel {
                     }
                     break;
                 case "contour":
-                    // Not editable at the moment (TODO)
+                case "point":
+                    // Not editable at the moment
                     break;
-            }
+                }
         }
         // TODO(3d)
         // Iterate through 3d annotations here (e.g., bbox3)
@@ -16545,7 +16740,8 @@ class ULabel {
             switch (this.subtasks[this.state["current_subtask"]]["annotations"]["access"][edid]["spatial_type"]) {
                 case "bbox":
                 case "bbox3":
-                    // Can't propose new bounding box points
+                case "point":
+                    // Can't propose new bounding box or keypoint points
                     break;
                 case "polygon":
                     var npi = ULabel.get_nearest_point_on_polygon(
@@ -16943,6 +17139,11 @@ class ULabel {
                 this.suggest_edits(this.state["last_move"]);
             }
         }
+        else if (annotation_mode == "point") {
+            this.finish_annotation(null);
+            this.rebuild_containing_box(unq_id);
+            this.suggest_edits(this.state["last_move"]);
+        }
     }
     begin_annotation__undo(undo_payload) {
         // Parse necessary data
@@ -17019,6 +17220,15 @@ class ULabel {
         for (var pti = 1; pti < npts; pti++) {
             this.update_containing_box(this.subtasks[subtask]["annotations"]["access"][actid]["spatial_payload"][pti], actid, subtask);
         }
+        if (this.subtasks[subtask]["annotations"]["access"][actid]["spatial_type"]) {
+            let line_size = this.subtasks[subtask]["annotations"]["access"][actid]["line_size"];
+            this.subtasks[subtask]["annotations"]["access"][actid]["containing_box"]["tlx"] -= 3*line_size;
+            this.subtasks[subtask]["annotations"]["access"][actid]["containing_box"]["tly"] -= 3*line_size;
+            this.subtasks[subtask]["annotations"]["access"][actid]["containing_box"]["brx"] += 3*line_size;
+            this.subtasks[subtask]["annotations"]["access"][actid]["containing_box"]["bry"] += 3*line_size;
+        }
+        console.log(this.subtasks[subtask]["annotations"]["access"][actid]["containing_box"]);
+        // TODO modification here for T-Bar would be nice too
     }
 
     continue_annotation(mouse_event, isclick=false, redo_payload=null) {
@@ -17515,6 +17725,7 @@ class ULabel {
             case "bbox3":
             case "contour":
             case "tbar":
+            case "point":
                 this.record_finish(actid);
                 // tobuffer this is where the annotation moves to back canvas
                 break;
@@ -17586,6 +17797,7 @@ class ULabel {
                 this.record_finish_edit(actid);
                 break;
             case "contour":
+            case "point":
                 // tobuffer this is where the annotation moves to back canvas
                 break;
             default:
@@ -17624,6 +17836,7 @@ class ULabel {
             case "bbox3":
             case "contour":
             case "tbar":
+            case "point":
                 // tobuffer this is where the annotation moves to back canvas
                 break;
             default:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "ulabel",
-  "version": "0.4.7",
+  "version": "0.4.8-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.4.7",
+      "version": "0.4.8-dev",
       "license": "MIT",
       "dependencies": {
         "express": "^4.17.1",
@@ -137,6 +137,30 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
@@ -205,9 +229,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.14.33",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.33.tgz",
-      "integrity": "sha512-oJqcTrgPUF29oUP8AsUqbXGJNuPutsetaa9kTQAQce5Lx5dTYWV02ScBiT/k1BX/Z7pKeqedmvp39Wu4zR7N7g==",
+      "version": "14.14.35",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
+      "integrity": "sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==",
       "dev": true
     },
     "node_modules/@types/uuid": {
@@ -216,13 +240,13 @@
       "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.17.0.tgz",
-      "integrity": "sha512-/fKFDcoHg8oNan39IKFOb5WmV7oWhQe1K6CDaAVfJaNWEhmfqlA24g+u1lqU5bMH7zuNasfMId4LaYWC5ijRLw==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.18.0.tgz",
+      "integrity": "sha512-Lzkc/2+7EoH7+NjIWLS2lVuKKqbEmJhtXe3rmfA8cyiKnZm3IfLf51irnBcmow8Q/AptVV0XBZmBJKuUJTe6cQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "4.17.0",
-        "@typescript-eslint/scope-manager": "4.17.0",
+        "@typescript-eslint/experimental-utils": "4.18.0",
+        "@typescript-eslint/scope-manager": "4.18.0",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "lodash": "^4.17.15",
@@ -248,15 +272,15 @@
       }
     },
     "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.17.0.tgz",
-      "integrity": "sha512-ZR2NIUbnIBj+LGqCFGQ9yk2EBQrpVVFOh9/Kd0Lm6gLpSAcCuLLe5lUCibKGCqyH9HPwYC0GIJce2O1i8VYmWA==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.18.0.tgz",
+      "integrity": "sha512-92h723Kblt9JcT2RRY3QS2xefFKar4ZQFVs3GityOKWQYgtajxt/tuXIzL7sVCUlM1hgreiV5gkGYyBpdOwO6A==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.17.0",
-        "@typescript-eslint/types": "4.17.0",
-        "@typescript-eslint/typescript-estree": "4.17.0",
+        "@typescript-eslint/scope-manager": "4.18.0",
+        "@typescript-eslint/types": "4.18.0",
+        "@typescript-eslint/typescript-estree": "4.18.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       },
@@ -272,14 +296,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.17.0.tgz",
-      "integrity": "sha512-KYdksiZQ0N1t+6qpnl6JeK9ycCFprS9xBAiIrw4gSphqONt8wydBw4BXJi3C11ywZmyHulvMaLjWsxDjUSDwAw==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.18.0.tgz",
+      "integrity": "sha512-W3z5S0ZbecwX3PhJEAnq4mnjK5JJXvXUDBYIYGoweCyWyuvAKfGHvzmpUzgB5L4cRBb+cTu9U/ro66dx7dIimA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "4.17.0",
-        "@typescript-eslint/types": "4.17.0",
-        "@typescript-eslint/typescript-estree": "4.17.0",
+        "@typescript-eslint/scope-manager": "4.18.0",
+        "@typescript-eslint/types": "4.18.0",
+        "@typescript-eslint/typescript-estree": "4.18.0",
         "debug": "^4.1.1"
       },
       "engines": {
@@ -299,13 +323,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.17.0.tgz",
-      "integrity": "sha512-OJ+CeTliuW+UZ9qgULrnGpPQ1bhrZNFpfT/Bc0pzNeyZwMik7/ykJ0JHnQ7krHanFN9wcnPK89pwn84cRUmYjw==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.18.0.tgz",
+      "integrity": "sha512-olX4yN6rvHR2eyFOcb6E4vmhDPsfdMyfQ3qR+oQNkAv8emKKlfxTWUXU5Mqxs2Fwe3Pf1BoPvrwZtwngxDzYzQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.17.0",
-        "@typescript-eslint/visitor-keys": "4.17.0"
+        "@typescript-eslint/types": "4.18.0",
+        "@typescript-eslint/visitor-keys": "4.18.0"
       },
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -316,9 +340,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.17.0.tgz",
-      "integrity": "sha512-RN5z8qYpJ+kXwnLlyzZkiJwfW2AY458Bf8WqllkondQIcN2ZxQowAToGSd9BlAUZDB5Ea8I6mqL2quGYCLT+2g==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.18.0.tgz",
+      "integrity": "sha512-/BRociARpj5E+9yQ7cwCF/SNOWwXJ3qhjurMuK2hIFUbr9vTuDeu476Zpu+ptxY2kSxUHDGLLKy+qGq2sOg37A==",
       "dev": true,
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -329,13 +353,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.17.0.tgz",
-      "integrity": "sha512-lRhSFIZKUEPPWpWfwuZBH9trYIEJSI0vYsrxbvVvNyIUDoKWaklOAelsSkeh3E2VBSZiNe9BZ4E5tYBZbUczVQ==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.18.0.tgz",
+      "integrity": "sha512-wt4xvF6vvJI7epz+rEqxmoNQ4ZADArGQO9gDU+cM0U5fdVv7N+IAuVoVAoZSOZxzGHBfvE3XQMLdy+scsqFfeg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.17.0",
-        "@typescript-eslint/visitor-keys": "4.17.0",
+        "@typescript-eslint/types": "4.18.0",
+        "@typescript-eslint/visitor-keys": "4.18.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-glob": "^4.0.1",
@@ -356,12 +380,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.17.0.tgz",
-      "integrity": "sha512-WfuMN8mm5SSqXuAr9NM+fItJ0SVVphobWYkWOwQ1odsfC014Vdxk/92t4JwS1Q6fCA/ABfCKpa3AVtpUKTNKGQ==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.18.0.tgz",
+      "integrity": "sha512-Q9t90JCvfYaN0OfFUgaLqByOfz8yPeTAdotn/XYNm5q9eHax90gzdb+RJ6E9T5s97Kv/UHWKERTmqA0jTKAEHw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.17.0",
+        "@typescript-eslint/types": "4.18.0",
         "eslint-visitor-keys": "^2.0.0"
       },
       "engines": {
@@ -797,9 +821,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001198",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001198.tgz",
-      "integrity": "sha512-r5GGgESqOPZzwvdLVER374FpQu2WluCF1Z2DSiFJ89KSmGjT0LVKjgv4NcAqHmGWF9ihNpqRI9KXO9Ex4sKsgA==",
+      "version": "1.0.30001202",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001202.tgz",
+      "integrity": "sha512-ZcijQNqrcF8JNLjzvEiXqX4JUYxoZa7Pvcsd9UD8Kz4TvhTonOSNRsK+qtvpVL4l6+T1Rh4LFtLfnNWg6BGWCQ==",
       "dev": true
     },
     "node_modules/chalk": {
@@ -992,9 +1016,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.684",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.684.tgz",
-      "integrity": "sha512-GV/vz2EmmtRSvfGSQ5A0Lucic//IRSDijgL15IgzbBEEnp4rfbxeUSZSlBfmsj7BQvE4sBdgfsvPzLCnp6L21w==",
+      "version": "1.3.690",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.690.tgz",
+      "integrity": "sha512-zPbaSv1c8LUKqQ+scNxJKv01RYFkVVF1xli+b+3Ty8ONujHjAMg+t/COmdZqrtnS1gT+g4hbSodHillymt1Lww==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -1078,9 +1102,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.21.0.tgz",
-      "integrity": "sha512-W2aJbXpMNofUp0ztQaF40fveSsJBjlSCSWpy//gzfTvwC+USs/nceBrKmlJOiM8r1bLwP2EuYkCqArn/6QTIgg==",
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.22.0.tgz",
+      "integrity": "sha512-3VawOtjSJUQiiqac8MQc+w457iGLfuNGLFn8JmF051tTKbh5/x/0vlcEj8OgDCaw7Ysa2Jn8paGshV7x2abKXg==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
@@ -1100,7 +1124,7 @@
         "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^5.0.0",
-        "globals": "^12.1.0",
+        "globals": "^13.6.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
@@ -1108,7 +1132,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.21",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -1587,12 +1611,12 @@
       "dev": true
     },
     "node_modules/globals": {
-      "version": "12.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.6.0.tgz",
+      "integrity": "sha512-YFKCX0SiPg7l5oKYCJ2zZGxcXprVXHcSnVuvzrT3oSENQonVLqM5pf9fN5dLGZGyCjhw8TN8Btwe/jKnZ0pjvQ==",
       "dev": true,
       "dependencies": {
-        "type-fest": "^0.8.1"
+        "type-fest": "^0.20.2"
       },
       "engines": {
         "node": ">=8"
@@ -2969,12 +2993,15 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -3073,9 +3100,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.24.4",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.24.4.tgz",
-      "integrity": "sha512-RXOdxF9hFFFhg47BryCgyFrEyyu7Y/75/uiI2DoUiTMqysK+WczVSTppvkR47oZcmI/DPaXCiCiaXBP8QjkNpA==",
+      "version": "5.26.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.26.3.tgz",
+      "integrity": "sha512-z/F2lt2N1fZqaud1B4SzjL3OW03eULThbBXQ2OX4LSrZX4N9k1A5d0Rje3zS2g887DTWyAV0KGqEf64ois2dhg==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.0",
@@ -3368,6 +3395,23 @@
         "js-yaml": "^3.13.1",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
+        }
       }
     },
     "@nodelib/fs.scandir": {
@@ -3429,9 +3473,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.33",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.33.tgz",
-      "integrity": "sha512-oJqcTrgPUF29oUP8AsUqbXGJNuPutsetaa9kTQAQce5Lx5dTYWV02ScBiT/k1BX/Z7pKeqedmvp39Wu4zR7N7g==",
+      "version": "14.14.35",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
+      "integrity": "sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==",
       "dev": true
     },
     "@types/uuid": {
@@ -3440,13 +3484,13 @@
       "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ=="
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.17.0.tgz",
-      "integrity": "sha512-/fKFDcoHg8oNan39IKFOb5WmV7oWhQe1K6CDaAVfJaNWEhmfqlA24g+u1lqU5bMH7zuNasfMId4LaYWC5ijRLw==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.18.0.tgz",
+      "integrity": "sha512-Lzkc/2+7EoH7+NjIWLS2lVuKKqbEmJhtXe3rmfA8cyiKnZm3IfLf51irnBcmow8Q/AptVV0XBZmBJKuUJTe6cQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.17.0",
-        "@typescript-eslint/scope-manager": "4.17.0",
+        "@typescript-eslint/experimental-utils": "4.18.0",
+        "@typescript-eslint/scope-manager": "4.18.0",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "lodash": "^4.17.15",
@@ -3456,55 +3500,55 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.17.0.tgz",
-      "integrity": "sha512-ZR2NIUbnIBj+LGqCFGQ9yk2EBQrpVVFOh9/Kd0Lm6gLpSAcCuLLe5lUCibKGCqyH9HPwYC0GIJce2O1i8VYmWA==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.18.0.tgz",
+      "integrity": "sha512-92h723Kblt9JcT2RRY3QS2xefFKar4ZQFVs3GityOKWQYgtajxt/tuXIzL7sVCUlM1hgreiV5gkGYyBpdOwO6A==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.17.0",
-        "@typescript-eslint/types": "4.17.0",
-        "@typescript-eslint/typescript-estree": "4.17.0",
+        "@typescript-eslint/scope-manager": "4.18.0",
+        "@typescript-eslint/types": "4.18.0",
+        "@typescript-eslint/typescript-estree": "4.18.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.17.0.tgz",
-      "integrity": "sha512-KYdksiZQ0N1t+6qpnl6JeK9ycCFprS9xBAiIrw4gSphqONt8wydBw4BXJi3C11ywZmyHulvMaLjWsxDjUSDwAw==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.18.0.tgz",
+      "integrity": "sha512-W3z5S0ZbecwX3PhJEAnq4mnjK5JJXvXUDBYIYGoweCyWyuvAKfGHvzmpUzgB5L4cRBb+cTu9U/ro66dx7dIimA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.17.0",
-        "@typescript-eslint/types": "4.17.0",
-        "@typescript-eslint/typescript-estree": "4.17.0",
+        "@typescript-eslint/scope-manager": "4.18.0",
+        "@typescript-eslint/types": "4.18.0",
+        "@typescript-eslint/typescript-estree": "4.18.0",
         "debug": "^4.1.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.17.0.tgz",
-      "integrity": "sha512-OJ+CeTliuW+UZ9qgULrnGpPQ1bhrZNFpfT/Bc0pzNeyZwMik7/ykJ0JHnQ7krHanFN9wcnPK89pwn84cRUmYjw==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.18.0.tgz",
+      "integrity": "sha512-olX4yN6rvHR2eyFOcb6E4vmhDPsfdMyfQ3qR+oQNkAv8emKKlfxTWUXU5Mqxs2Fwe3Pf1BoPvrwZtwngxDzYzQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.17.0",
-        "@typescript-eslint/visitor-keys": "4.17.0"
+        "@typescript-eslint/types": "4.18.0",
+        "@typescript-eslint/visitor-keys": "4.18.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.17.0.tgz",
-      "integrity": "sha512-RN5z8qYpJ+kXwnLlyzZkiJwfW2AY458Bf8WqllkondQIcN2ZxQowAToGSd9BlAUZDB5Ea8I6mqL2quGYCLT+2g==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.18.0.tgz",
+      "integrity": "sha512-/BRociARpj5E+9yQ7cwCF/SNOWwXJ3qhjurMuK2hIFUbr9vTuDeu476Zpu+ptxY2kSxUHDGLLKy+qGq2sOg37A==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.17.0.tgz",
-      "integrity": "sha512-lRhSFIZKUEPPWpWfwuZBH9trYIEJSI0vYsrxbvVvNyIUDoKWaklOAelsSkeh3E2VBSZiNe9BZ4E5tYBZbUczVQ==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.18.0.tgz",
+      "integrity": "sha512-wt4xvF6vvJI7epz+rEqxmoNQ4ZADArGQO9gDU+cM0U5fdVv7N+IAuVoVAoZSOZxzGHBfvE3XQMLdy+scsqFfeg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.17.0",
-        "@typescript-eslint/visitor-keys": "4.17.0",
+        "@typescript-eslint/types": "4.18.0",
+        "@typescript-eslint/visitor-keys": "4.18.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-glob": "^4.0.1",
@@ -3513,12 +3557,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.17.0.tgz",
-      "integrity": "sha512-WfuMN8mm5SSqXuAr9NM+fItJ0SVVphobWYkWOwQ1odsfC014Vdxk/92t4JwS1Q6fCA/ABfCKpa3AVtpUKTNKGQ==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.18.0.tgz",
+      "integrity": "sha512-Q9t90JCvfYaN0OfFUgaLqByOfz8yPeTAdotn/XYNm5q9eHax90gzdb+RJ6E9T5s97Kv/UHWKERTmqA0jTKAEHw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.17.0",
+        "@typescript-eslint/types": "4.18.0",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -3879,9 +3923,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001198",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001198.tgz",
-      "integrity": "sha512-r5GGgESqOPZzwvdLVER374FpQu2WluCF1Z2DSiFJ89KSmGjT0LVKjgv4NcAqHmGWF9ihNpqRI9KXO9Ex4sKsgA==",
+      "version": "1.0.30001202",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001202.tgz",
+      "integrity": "sha512-ZcijQNqrcF8JNLjzvEiXqX4JUYxoZa7Pvcsd9UD8Kz4TvhTonOSNRsK+qtvpVL4l6+T1Rh4LFtLfnNWg6BGWCQ==",
       "dev": true
     },
     "chalk": {
@@ -4030,9 +4074,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.684",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.684.tgz",
-      "integrity": "sha512-GV/vz2EmmtRSvfGSQ5A0Lucic//IRSDijgL15IgzbBEEnp4rfbxeUSZSlBfmsj7BQvE4sBdgfsvPzLCnp6L21w==",
+      "version": "1.3.690",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.690.tgz",
+      "integrity": "sha512-zPbaSv1c8LUKqQ+scNxJKv01RYFkVVF1xli+b+3Ty8ONujHjAMg+t/COmdZqrtnS1gT+g4hbSodHillymt1Lww==",
       "dev": true
     },
     "emoji-regex": {
@@ -4095,9 +4139,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.21.0.tgz",
-      "integrity": "sha512-W2aJbXpMNofUp0ztQaF40fveSsJBjlSCSWpy//gzfTvwC+USs/nceBrKmlJOiM8r1bLwP2EuYkCqArn/6QTIgg==",
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.22.0.tgz",
+      "integrity": "sha512-3VawOtjSJUQiiqac8MQc+w457iGLfuNGLFn8JmF051tTKbh5/x/0vlcEj8OgDCaw7Ysa2Jn8paGshV7x2abKXg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
@@ -4117,7 +4161,7 @@
         "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^5.0.0",
-        "globals": "^12.1.0",
+        "globals": "^13.6.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
@@ -4125,7 +4169,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.21",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -4507,12 +4551,12 @@
       "dev": true
     },
     "globals": {
-      "version": "12.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.6.0.tgz",
+      "integrity": "sha512-YFKCX0SiPg7l5oKYCJ2zZGxcXprVXHcSnVuvzrT3oSENQonVLqM5pf9fN5dLGZGyCjhw8TN8Btwe/jKnZ0pjvQ==",
       "dev": true,
       "requires": {
-        "type-fest": "^0.8.1"
+        "type-fest": "^0.20.2"
       }
     },
     "globby": {
@@ -5523,9 +5567,9 @@
       }
     },
     "type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true
     },
     "type-is": {
@@ -5599,9 +5643,9 @@
       }
     },
     "webpack": {
-      "version": "5.24.4",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.24.4.tgz",
-      "integrity": "sha512-RXOdxF9hFFFhg47BryCgyFrEyyu7Y/75/uiI2DoUiTMqysK+WczVSTppvkR47oZcmI/DPaXCiCiaXBP8QjkNpA==",
+      "version": "5.26.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.26.3.tgz",
+      "integrity": "sha512-z/F2lt2N1fZqaud1B4SzjL3OW03eULThbBXQ2OX4LSrZX4N9k1A5d0Rje3zS2g887DTWyAV0KGqEf64ois2dhg==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "ulabel",
-  "version": "0.4.8-dev",
+  "version": "0.4.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.4.8-dev",
+      "version": "0.4.8",
       "license": "MIT",
       "dependencies": {
         "express": "^4.17.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ulabel",
   "description": "An image annotation tool.",
-  "version": "0.4.8-dev",
+  "version": "0.4.8",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ulabel",
   "description": "An image annotation tool.",
-  "version": "0.4.7",
+  "version": "0.4.8-dev",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -6,7 +6,7 @@
 
 ## PR Checklist
 
-- [ ] Merged latest master
+- [ ] Merged latest main
 - [ ] Version number in `package.json` has been bumped since last release
 - [ ] Version numbers match between package `package.json` and `src/version.js`
 - [ ] Ran `npm install` and `npm run build` AFTER bumping the version number

--- a/src/blobs.js
+++ b/src/blobs.js
@@ -93,6 +93,147 @@ const BBOX_SVG = `
   </g>
 </svg>
 `;
+const POINT_SVG = `
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="100mm"
+   height="100mm"
+   viewBox="0 0 100 100"
+   version="1.1"
+   id="svg7244"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="point.svg">
+  <defs
+     id="defs7238">
+    <marker
+       inkscape:stockid="DotL"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="marker1156"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1154"
+         d="M -2.5,-1.0 C -2.5,1.7600000 -4.7400000,4.0 -7.5,4.0 C -10.260000,4.0 -12.5,1.7600000 -12.5,-1.0 C -12.5,-3.7600000 -10.260000,-6.0 -7.5,-6.0 C -4.7400000,-6.0 -2.5,-3.7600000 -2.5,-1.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) translate(7.4, 1)" />
+    </marker>
+    <marker
+       inkscape:stockid="DotL"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="marker1152"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1150"
+         d="M -2.5,-1.0 C -2.5,1.7600000 -4.7400000,4.0 -7.5,4.0 C -10.260000,4.0 -12.5,1.7600000 -12.5,-1.0 C -12.5,-3.7600000 -10.260000,-6.0 -7.5,-6.0 C -4.7400000,-6.0 -2.5,-3.7600000 -2.5,-1.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) translate(7.4, 1)" />
+    </marker>
+    <marker
+       inkscape:stockid="DotL"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="marker1148"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path946"
+         d="M -2.5,-1.0 C -2.5,1.7600000 -4.7400000,4.0 -7.5,4.0 C -10.260000,4.0 -12.5,1.7600000 -12.5,-1.0 C -12.5,-3.7600000 -10.260000,-6.0 -7.5,-6.0 C -4.7400000,-6.0 -2.5,-3.7600000 -2.5,-1.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) translate(7.4, 1)" />
+    </marker>
+    <marker
+       inkscape:stockid="DotL"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="DotL"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4587"
+         d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(0.8,0,0,0.8,5.92,0.8)" />
+    </marker>
+    <marker
+       inkscape:stockid="DotL"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7235"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path7233"
+         d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(0.8,0,0,0.8,5.92,0.8)" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.1443229"
+     inkscape:cx="138.27833"
+     inkscape:cy="159.299"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1043"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7241">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-197)">
+    <circle
+       style="fill:#fedbdb;fill-opacity:0;stroke:#000000;stroke-width:3.34195209;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       id="path884"
+       cx="50"
+       cy="247"
+       r="23.329023" />
+    <circle
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1.06185877;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       id="path886"
+       cx="50"
+       cy="247"
+       r="6.9690704" />
+  </g>
+</svg>
+`;
 const POLYGON_SVG = `
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
@@ -2013,7 +2154,7 @@ const COLORS = [
 ];
 
 export { 
-   BBOX_SVG, BBOX3_SVG, POLYGON_SVG, CONTOUR_SVG, TBAR_SVG, POLYLINE_SVG, WHOLE_IMAGE_SVG, GLOBAL_SVG, 
+   BBOX_SVG, BBOX3_SVG, POINT_SVG, POLYGON_SVG, CONTOUR_SVG, TBAR_SVG, POLYLINE_SVG, WHOLE_IMAGE_SVG, GLOBAL_SVG, 
    DEMO_ANNOTATION, 
    get_init_style, 
    COLORS 

--- a/src/index.js
+++ b/src/index.js
@@ -1420,7 +1420,8 @@ class ULabel {
         annotation_meta=null,
         px_per_px=1,
         initial_crop=null,
-        initial_line_size=4
+        initial_line_size=4,
+        instructions_url=null
     ) {
         // Unroll safe default arguments
         if (task_meta == null) {task_meta = {};}
@@ -1475,6 +1476,7 @@ class ULabel {
             // Behavior on special interactions
             "done_callback": on_submit_unrolled.hook,
             "done_button": on_submit_unrolled.name,
+            "instructions_url": instructions_url,
 
             // ID Dialog config
             "cl_opacity": 0.4,

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import {
     DEMO_ANNOTATION, 
     BBOX_SVG, 
     BBOX3_SVG,
+    POINT_SVG,
     POLYGON_SVG, 
     CONTOUR_SVG, 
     get_init_style, 
@@ -570,6 +571,7 @@ class ULabel {
         let curmd = ul.subtasks[crst]["state"]["annotation_mode"];
         let md_buttons = [
             ULabel.get_md_button("bbox", "Bounding Box", BBOX_SVG, curmd, ul.subtasks),
+            ULabel.get_md_button("point", "Point", POINT_SVG, curmd, ul.subtasks),
             ULabel.get_md_button("polygon", "Polygon", POLYGON_SVG, curmd, ul.subtasks),
             ULabel.get_md_button("tbar", "T-Bar", TBAR_SVG, curmd, ul.subtasks),
             ULabel.get_md_button("polyline", "Polyline", POLYLINE_SVG, curmd, ul.subtasks),
@@ -1844,6 +1846,10 @@ class ULabel {
     // Get the start of a spatial payload based on mouse event and current annotation mode
     get_init_spatial(gmx, gmy, annotation_mode) {
         switch (annotation_mode) {
+            case "point":
+                return [
+                    [gmx, gmy]
+                ];
             case "bbox":
             case "polygon":
             case "contour":
@@ -1882,6 +1888,8 @@ class ULabel {
                 bbj = parseInt(access_str[1], 10);
                 bbox_pts = this.subtasks[this.state["current_subtask"]]["annotations"]["access"][annid]["spatial_payload"];
                 return [bbox_pts[bbi][0], bbox_pts[bbj][1]];
+            case "point":
+                return JSON.parse(JSON.stringify(this.subtasks[this.state["current_subtask"]]["annotations"]["access"][annid]["spatial_payload"]));
             case "bbox3":
                 // TODO(3d)
                 bbi = parseInt(access_str[0], 10);
@@ -1939,6 +1947,10 @@ class ULabel {
                 bbj = parseInt(access_str[1], 10);
                 this.subtasks[this.state["current_subtask"]]["annotations"]["access"][annid]["spatial_payload"][bbi][0] = val[0];
                 this.subtasks[this.state["current_subtask"]]["annotations"]["access"][annid]["spatial_payload"][bbj][1] = val[1];
+                break;
+            case "point":
+                this.subtasks[this.state["current_subtask"]]["annotations"]["access"][annid]["spatial_payload"][bbi][0] = val[0];
+                this.subtasks[this.state["current_subtask"]]["annotations"]["access"][annid]["spatial_payload"][bbi][0] = val[0];
                 break;
             case "bbox3":
                 bbi = parseInt(access_str[0], 10);
@@ -2078,6 +2090,45 @@ class ULabel {
         ctx.lineTo((ep[0] + diffX)*px_per_px, (ep[1] + diffY)*px_per_px);
         ctx.lineTo((ep[0] + diffX)*px_per_px, (sp[1] + diffY)*px_per_px);
         ctx.lineTo((sp[0] + diffX)*px_per_px, (sp[1] + diffY)*px_per_px);
+        ctx.closePath();
+        ctx.stroke();
+    }
+
+    draw_point(annotation_object, ctx, demo=false, offset=null, subtask=null) {
+        const px_per_px = this.config["px_per_px"];
+        let diffX = 0;
+        let diffY = 0;
+        if (offset != null) {
+            diffX = offset["diffX"];
+            diffY = offset["diffY"];
+        }
+
+        let line_size = null;
+        if ("line_size" in annotation_object) {
+            line_size = annotation_object["line_size"];
+        }
+        else {
+            line_size = this.get_line_size(demo);
+        }
+    
+        // Prep for bbox drawing
+        let color = this.get_annotation_color(annotation_object["classification_payloads"], false, subtask);
+        ctx.fillStyle = color;
+        ctx.strokeStyle = color;
+        ctx.lineJoin = "round";
+        ctx.lineWidth = line_size*px_per_px;
+        ctx.imageSmoothingEnabled = false;
+        ctx.globalCompositeOperation = "source-over";
+    
+        // Draw the box
+        const sp = annotation_object["spatial_payload"][0];
+        ctx.beginPath();
+        ctx.arc((sp[0] + diffX)*px_per_px, (sp[1] + diffY)*px_per_px, line_size*px_per_px*0.75, 0, 2*Math.PI);
+        ctx.closePath();
+        ctx.stroke();
+        ctx.fill();
+        ctx.beginPath();
+        ctx.arc((sp[0] + diffX)*px_per_px, (sp[1] + diffY)*px_per_px, line_size*px_per_px*3, 0, 2*Math.PI);
         ctx.closePath();
         ctx.stroke();
     }
@@ -2364,6 +2415,9 @@ class ULabel {
         switch (annotation_object["spatial_type"]) {
             case "bbox":
                 this.draw_bounding_box(annotation_object, ctx, demo, offset, subtask);
+                break;
+            case "point":
+                this.draw_point(annotation_object, ctx, demo, offset, subtask);
                 break;
             case "bbox3":
                 // TODO(new3d)
@@ -2890,9 +2944,10 @@ class ULabel {
                     }
                     break;
                 case "contour":
-                    // Not editable at the moment (TODO)
+                case "point":
+                    // Not editable at the moment
                     break;
-            }
+                }
         }
         // TODO(3d)
         // Iterate through 3d annotations here (e.g., bbox3)
@@ -2917,7 +2972,8 @@ class ULabel {
             switch (this.subtasks[this.state["current_subtask"]]["annotations"]["access"][edid]["spatial_type"]) {
                 case "bbox":
                 case "bbox3":
-                    // Can't propose new bounding box points
+                case "point":
+                    // Can't propose new bounding box or keypoint points
                     break;
                 case "polygon":
                     var npi = ULabel.get_nearest_point_on_polygon(
@@ -3315,6 +3371,11 @@ class ULabel {
                 this.suggest_edits(this.state["last_move"]);
             }
         }
+        else if (annotation_mode == "point") {
+            this.finish_annotation(null);
+            this.rebuild_containing_box(unq_id);
+            this.suggest_edits(this.state["last_move"]);
+        }
     }
     begin_annotation__undo(undo_payload) {
         // Parse necessary data
@@ -3391,6 +3452,14 @@ class ULabel {
         for (var pti = 1; pti < npts; pti++) {
             this.update_containing_box(this.subtasks[subtask]["annotations"]["access"][actid]["spatial_payload"][pti], actid, subtask);
         }
+        if (this.subtasks[subtask]["annotations"]["access"][actid]["spatial_type"]) {
+            let line_size = this.subtasks[subtask]["annotations"]["access"][actid]["line_size"];
+            this.subtasks[subtask]["annotations"]["access"][actid]["containing_box"]["tlx"] -= 3*line_size;
+            this.subtasks[subtask]["annotations"]["access"][actid]["containing_box"]["tly"] -= 3*line_size;
+            this.subtasks[subtask]["annotations"]["access"][actid]["containing_box"]["brx"] += 3*line_size;
+            this.subtasks[subtask]["annotations"]["access"][actid]["containing_box"]["bry"] += 3*line_size;
+        }
+        // TODO modification here for T-Bar would be nice too
     }
 
     continue_annotation(mouse_event, isclick=false, redo_payload=null) {
@@ -3887,6 +3956,7 @@ class ULabel {
             case "bbox3":
             case "contour":
             case "tbar":
+            case "point":
                 this.record_finish(actid);
                 // tobuffer this is where the annotation moves to back canvas
                 break;
@@ -3958,6 +4028,7 @@ class ULabel {
                 this.record_finish_edit(actid);
                 break;
             case "contour":
+            case "point":
                 // tobuffer this is where the annotation moves to back canvas
                 break;
             default:
@@ -3996,6 +4067,7 @@ class ULabel {
             case "bbox3":
             case "contour":
             case "tbar":
+            case "point":
                 // tobuffer this is where the annotation moves to back canvas
                 break;
             default:

--- a/src/index.js
+++ b/src/index.js
@@ -1083,7 +1083,7 @@ class ULabel {
                     );
                 }
             }
-            if (ul.config["done_callback"](submit_payload) !== false) {
+            if (ul.config["done_callback"].bind(ul)(submit_payload) !== false) {
                 ul.set_saved(true);
             }
         });

--- a/src/index.js
+++ b/src/index.js
@@ -1084,8 +1084,7 @@ class ULabel {
                 }
             }
             if (ul.config["done_callback"](submit_payload) !== false) {
-                ul.state["edited"] = false;
-                $("#"+ul.config["container_id"] + " a#submit-button").removeAttr("href");
+                ul.set_saved(true);
             }
         });
 
@@ -2965,9 +2964,18 @@ class ULabel {
 
     // Action Stream Events
 
+    set_saved(saved) {
+        if (saved) {
+            $("#"+this.config["container_id"] + " a#submit-button").removeAttr("href");
+        }
+        else {
+            $("#"+this.config["container_id"] + " a#submit-button").attr("href", "#");
+        }
+        this.state["edited"] = !saved;
+    }
+
     record_action(action, is_redo=false) {
-        $("#"+this.config["container_id"] + " a#submit-button").attr("href", "#");
-        this.state["edited"] = true;
+        this.set_saved(false);
 
         // After a new action, you can no longer redo old actions
         if (!is_redo) {

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export const ULABEL_VERSION = "0.4.8-dev";
+export const ULABEL_VERSION = "0.4.8";

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export const ULABEL_VERSION = "0.4.7";
+export const ULABEL_VERSION = "0.4.8-dev";


### PR DESCRIPTION
# Support for an Instructions Link, set_saved(), and Point Annotations

## Description

The constructor now accepts a link to a document with instructions, and the submit callback now binds the ulabel instance so that `set_saved()` can be called before page unloading, if desired. Finally, the new annotation mode of "Points" has been added.

## PR Checklist

- [x] Merged latest master
- [x] Version number in `package.json` has been bumped since last release
- [x] Version numbers match between package `package.json` and `src/version.js`
- [x] Ran `npm install` and `npm run build` AFTER bumping the version number
- [x] Updated documentation if necessary (currently just in `api_spec.md`)
- [x] Added changes to `changelog.md`

## Breaking API Changes

None.
