### PR TITLE
FIX main attribute pointing to wrong file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ulabel",
   "description": "An image annotation tool.",
   "version": "0.4.8",
-  "main": "index.js",
+  "main": "src/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "webpack --mode production",


### PR DESCRIPTION
# main attribute pointing to wrong file

I could not import the module because the main field in the  `package.json` points to a non existing file.
This PR changes it to just point to the index in the `src` directory.