### PR TITLE
Fixed minor problems

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -33,25 +33,49 @@ export type ULabelSubmitData = {
     task_meta: any;
 }
 export type ULabelSubmitHandler = (submitData: ULabelSubmitData) => void;
-export type ULabelSpatialType = 'contour' | 'polygon' | 'bbox' | 'tbar';
+
+/**
+ * @link https://github.com/SenteraLLC/ulabel/blob/main/api_spec.md#subtasks
+ */
+export type ULabelSpatialType = 'contour' | 'polygon' | 'bbox' | 'tbar' | 'bbox3' | 'whole-image' | 'global' | 'point';
+
 export type ULabelSubtask = {
     display_name: string,
     classes: { name: string, color: string, id: number }[],
     allowed_modes: ULabelSpatialType[],
-    resume_from: any,
+    resume_from: ULabelAnnotation[],
     task_meta: any,
     annotation_meta: any
+    read_only?: boolean;
 }
 export type ULabelSubtasks = { [key: string]: ULabelSubtask };
 
 export class ULabel {
+    /**
+     * @link https://github.com/SenteraLLC/ulabel/blob/main/api_spec.md#ulabel-constructor
+     */
     constructor(
         container_id: string,
-        image_url: string,
+        image_data: string | string[],
         username: string,
         on_submit: ULabelSubmitHandler,
-        subtasks: ULabelSubtasks
+        subtasks: ULabelSubtasks,
+        task_meta?: any,
+        annotation_meta?: any,
+        px_per_px?: number,
+        init_crop?: any,
+        initial_line_size?: number,
+        instructions_url?: string
     )
 
+    /**
+     * @link https://github.com/SenteraLLC/ulabel/blob/main/api_spec.md#display-utility-functions
+     */
     public init(callback: () => void): void;
+    public swap_frame_image(new_src: string, frame?: number): string;
+    public swap_anno_bg_color(new_bg_color: string): string;
+    public get_annotations(subtask: ULabelSubtask): ULabelAnnotation[];
+    public set_annotations(annotations: ULabelAnnotation[], subtask: ULabelSubtask);
+    public set_saved(saved: boolean);
+
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,57 @@
+export type ULabelAnnotation = {
+    id: string;
+    new: boolean;
+    parent_id: null | string;
+    created_by: string;
+    /**
+     * date like "2021-03-30T00:17:43.772Z"
+     */
+    created_at: string;
+    deprecated: boolean;
+    spatial_type: ULabelSpatialType;
+    spatial_payload: [number, number][];
+    classification_payloads: {
+        class_id: number;
+        confidence: number;
+    }[];
+    line_size: number;
+    containing_box: {
+        tlx: number;
+        tly: number;
+        brx: number;
+        bry: number;
+        tlz: number;
+        brz: number;
+    },
+    frame: number;
+    text_payload: string;
+    annotation_meta: any;
+};
+export type ULabelAnnotations = { [key: string]: ULabelAnnotation[] };
+export type ULabelSubmitData = {
+    annotations: ULabelAnnotations;
+    task_meta: any;
+}
+export type ULabelSubmitHandler = (submitData: ULabelSubmitData) => void;
+export type ULabelSpatialType = 'contour' | 'polygon' | 'bbox' | 'tbar';
+export type ULabelSubtask = {
+    display_name: string,
+    classes: { name: string, color: string, id: number }[],
+    allowed_modes: ULabelSpatialType[],
+    resume_from: any,
+    task_meta: any,
+    annotation_meta: any
+}
+export type ULabelSubtasks = { [key: string]: ULabelSubtask };
+
+export class ULabel {
+    constructor(
+        container_id: string,
+        image_url: string,
+        username: string,
+        on_submit: ULabelSubmitHandler,
+        subtasks: ULabelSubtasks
+    )
+
+    public init(callback: () => void): void;
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "ulabel",
   "description": "An image annotation tool.",
   "version": "0.4.8",
-  "main": "index.js",
+  "main": "dist/ulabel.js",
+  "module": "src/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "webpack --mode production",
@@ -25,11 +26,11 @@
   },
   "homepage": "https://github.com/SenteraLLC/ulabel",
   "dependencies": {
-    "express": "^4.17.1",
     "jquery": "^3.5.1",
     "uuidv4": "^6.2.6"
   },
   "devDependencies": {
+    "express": "^4.17.1",
     "@typescript-eslint/eslint-plugin": "^4.16.1",
     "@typescript-eslint/parser": "^4.16.1",
     "eslint": "^7.21.0",

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ jQuery.fn.outer_html = function() {
 const MODES_3D = ["global", "bbox3"];
 const NONSPATIAL_MODES = ["whole-image", "global"];
 
-class ULabel {
+export class ULabel {
 
     // ================= Internal constants =================
 


### PR DESCRIPTION
# Fixed minor problems

## Description

I am using this labeler in my current project.
I had to make some changes so I am able to properly import it in my angular application.


## Changes
- Added basic `typescript` typings
- Fixed the main property in `package.json` so it points to a valid file. I also added the `module` field which points to the es6 module at the `src` folder
- I moved `express` to the `dev-dependencies` because users of this module do not need to install express for the frontend only component.
- I exported the `ULabel` class in the module so I can import it directly without accessing it via `window.ULabel`


## PR Checklist

- [X] Merged latest main
- [ ] Version number in `package.json` has been bumped since last release
- [ ] Version numbers match between package `package.json` and `src/version.js`
- [ ] Ran `npm install` and `npm run build` AFTER bumping the version number
- [ ] Updated documentation if necessary (currently just in `api_spec.md`)
- [ ] Added changes to `changelog.md`

## Breaking API Changes

None