### PR TITLE
fixed issue with keyboard shortcuts on ff and mac

### DIFF
--- a/api_spec.md
+++ b/api_spec.md
@@ -2,6 +2,13 @@
 
 This should eventually be replaced with a more comprehensive approach to documentation (e.g., via readthedocs.org), but this markdown file will do for now.
 
+## Keyboard Shortcuts
+
+- `ctrl+z` or `cmd+z`: Undo
+- `ctrl+shift+z` or `cmd+shift+z`: Redo
+- `ctrl+scroll` or `shift+scroll` or `cmd+scroll`: Zoom -- up for in, down for out
+- `scrollclick+drag` or `ctrl+drag`: Pan
+
 ## ULabel Constructor
 
 When the `ulabel.js` file is included, it attaches its class definition to the `window` object. Therefore, within the document, you may create a new annotation session with

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented here.
 
 <nothing_yet>
 
+## [0.4.12] - May 19, 2021
+
+- Fixed issue with detecting undo/redo on Firefox and Mac
+- Detected `shift+scroll` for zooming as well as `cmd/ctrl+scroll`
+- Fixed small issue with `beforeunload` warning
+
 ## [0.4.11] - May 18, 2021
 
 - Allow submission when page first loads without having to make an edit first

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -13812,7 +13812,7 @@ const COLORS = [
 
 
 ;// CONCATENATED MODULE: ./src/version.js
-const ULABEL_VERSION = "0.4.11";
+const ULABEL_VERSION = "0.4.12";
 ;// CONCATENATED MODULE: ./src/index.js
 /*
 Uncertain Labeling Tool

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -14102,7 +14102,7 @@ class ULabel {
         switch (mouse_event.button) {
             case 0:
                 if (mouse_event.target.id == ul.subtasks[ul.state["current_subtask"]]["canvas_fid"]) {
-                    if (mouse_event.ctrlKey) {
+                    if (mouse_event.ctrlKey || mouse_event.metaKey) {
                         return "pan";
                     }
                     if (mouse_event.shiftKey) {
@@ -14671,7 +14671,7 @@ class ULabel {
         // Detection ctrl+scroll
         document.getElementById(ul.config["annbox_id"]).onwheel = function (wheel_event) {
             let fms = ul.config["image_data"].frames.length > 1;
-            if (wheel_event.ctrlKey) {
+            if (wheel_event.ctrlKey || wheel_event.shiftKey || wheel_event.metaKey) {
                 // Prevent scroll-zoom
                 wheel_event.preventDefault();
 
@@ -14917,9 +14917,9 @@ class ULabel {
         })
 
         // Keyboard only events
-        jquery_default()(document).on("keypress", (keypress_event) => {
+        document.addEventListener("keydown", (keypress_event) => {
             const shift = keypress_event.shiftKey;
-            const ctrl = keypress_event.ctrlKey;
+            const ctrl = keypress_event.ctrlKey || keypress_event.metaKey;
             let fms = ul.config["image_data"].frames.length > 1;
             let annbox = jquery_default()("#"+ul.config["annbox_id"]);
             if (ctrl &&
@@ -15331,7 +15331,7 @@ class ULabel {
 
             // Renderings state
             "demo_canvas_context": null,
-            "edited": true
+            "edited": false
         };
 
         // Populate these in an external "static" function

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "ulabel",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.4.11",
+      "version": "0.4.12",
       "license": "MIT",
       "dependencies": {
         "jquery": "^3.5.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ulabel",
   "description": "An image annotation tool.",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "main": "index.js",
   "module": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -300,7 +300,7 @@ export class ULabel {
         switch (mouse_event.button) {
             case 0:
                 if (mouse_event.target.id == ul.subtasks[ul.state["current_subtask"]]["canvas_fid"]) {
-                    if (mouse_event.ctrlKey) {
+                    if (mouse_event.ctrlKey || mouse_event.metaKey) {
                         return "pan";
                     }
                     if (mouse_event.shiftKey) {
@@ -869,7 +869,7 @@ export class ULabel {
         // Detection ctrl+scroll
         document.getElementById(ul.config["annbox_id"]).onwheel = function (wheel_event) {
             let fms = ul.config["image_data"].frames.length > 1;
-            if (wheel_event.ctrlKey) {
+            if (wheel_event.ctrlKey || wheel_event.shiftKey || wheel_event.metaKey) {
                 // Prevent scroll-zoom
                 wheel_event.preventDefault();
 
@@ -1115,9 +1115,9 @@ export class ULabel {
         })
 
         // Keyboard only events
-        $(document).on("keypress", (keypress_event) => {
+        document.addEventListener("keydown", (keypress_event) => {
             const shift = keypress_event.shiftKey;
-            const ctrl = keypress_event.ctrlKey;
+            const ctrl = keypress_event.ctrlKey || keypress_event.metaKey;
             let fms = ul.config["image_data"].frames.length > 1;
             let annbox = $("#"+ul.config["annbox_id"]);
             if (ctrl &&
@@ -1529,7 +1529,7 @@ export class ULabel {
 
             // Renderings state
             "demo_canvas_context": null,
-            "edited": true
+            "edited": false
         };
 
         // Populate these in an external "static" function

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export const ULABEL_VERSION = "0.4.11";
+export const ULABEL_VERSION = "0.4.12";


### PR DESCRIPTION
# Better Keyboard Shortcut Support

## Description

- Fixed issue with detecting undo/redo on Firefox and Mac
- Detected shift+scroll for zooming as well as cmd/ctrl+scroll
- Fixed small issue with beforeunload warning

## PR Checklist

- [x] Merged latest main
- [x] Version number in `package.json` has been bumped since last release
- [x] Version numbers match between package `package.json` and `src/version.js`
- [x] Ran `npm install` and `npm run build` AFTER bumping the version number
- [x] Updated documentation if necessary (currently just in `api_spec.md`)
- [x] Added changes to `changelog.md`

## Breaking API Changes

None.
