### PR TITLE
added feature along with associated error checking

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented here.
 
 <nothing_yet>
 
+## [0.4.13] - May 24, 2021
+
+- ULabel now allows for classification payloads without items for certain classes, and just assumes that omitted classes have a confidence of zero
+
 ## [0.4.12] - May 19, 2021
 
 - Fixed issue with detecting undo/redo on Firefox and Mac

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -13812,7 +13812,7 @@ const COLORS = [
 
 
 ;// CONCATENATED MODULE: ./src/version.js
-const ULABEL_VERSION = "0.4.12";
+const ULABEL_VERSION = "0.4.13";
 ;// CONCATENATED MODULE: ./src/index.js
 /*
 Uncertain Labeling Tool
@@ -15074,7 +15074,7 @@ class ULabel {
             for (var i = 0; i < subtask["resume_from"].length; i++) {
                 // Push to ordering and add to access
                 ul.subtasks[subtask_key]["annotations"]["ordering"].push(subtask["resume_from"][i]["id"]);
-                ul.subtasks[subtask_key]["annotations"]["access"][subtask["resume_from"][i]["id"]] = subtask["resume_from"][i];
+                ul.subtasks[subtask_key]["annotations"]["access"][subtask["resume_from"][i]["id"]] = JSON.parse(JSON.stringify(subtask["resume_from"][i]));
 
                 // Set new to false
                 ul.subtasks[subtask_key]["annotations"]["access"][subtask["resume_from"][i]["id"]]["new"] = false;
@@ -15088,10 +15088,26 @@ class ULabel {
                 // TODO do I really want to do this?
 
                 // Ensure that classification payloads are compatible with config
-                // TODO
-
-                // Same for regression payloads
-                // TODO
+                let payloads = ul.subtasks[subtask_key]["annotations"]["access"][subtask["resume_from"][i]["id"]]["classification_payloads"];
+                let found_ids = [];
+                for (let j = 0; j < payloads.length; j++) {
+                    let this_id = payloads[j]["class_id"];
+                    if (!(ul.subtasks[subtask_key]["class_ids"].includes(this_id))) {
+                        alert(`Found class id ${this_id} in "resume_from" data but not in "allowed_classes"`);
+                        throw `Found class id ${this_id} in "resume_from" data but not in "allowed_classes"`;
+                    }
+                    found_ids.push(this_id);
+                }
+                for (let j = 0; j < ul.subtasks[subtask_key]["class_ids"].length; j++) {
+                    if (!(found_ids.includes(ul.subtasks[subtask_key]["class_ids"][j]))) {
+                        ul.subtasks[subtask_key]["annotations"]["access"][subtask["resume_from"][i]["id"]]["classification_payloads"].push(
+                            {
+                                "class_id": ul.subtasks[subtask_key]["class_ids"][j],
+                                "confidence": 0.0
+                            }
+                        )
+                    }
+                }
             }
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "ulabel",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.4.12",
+      "version": "0.4.13",
       "license": "MIT",
       "dependencies": {
         "jquery": "^3.5.1",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "ulabel",
   "description": "An image annotation tool.",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "main": "index.js",
   "module": "src/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
+    "demo": "node demo.js",
     "build": "webpack --mode production",
     "build-dev": "webpack --mode development"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1272,7 +1272,7 @@ export class ULabel {
             for (var i = 0; i < subtask["resume_from"].length; i++) {
                 // Push to ordering and add to access
                 ul.subtasks[subtask_key]["annotations"]["ordering"].push(subtask["resume_from"][i]["id"]);
-                ul.subtasks[subtask_key]["annotations"]["access"][subtask["resume_from"][i]["id"]] = subtask["resume_from"][i];
+                ul.subtasks[subtask_key]["annotations"]["access"][subtask["resume_from"][i]["id"]] = JSON.parse(JSON.stringify(subtask["resume_from"][i]));
 
                 // Set new to false
                 ul.subtasks[subtask_key]["annotations"]["access"][subtask["resume_from"][i]["id"]]["new"] = false;
@@ -1286,10 +1286,26 @@ export class ULabel {
                 // TODO do I really want to do this?
 
                 // Ensure that classification payloads are compatible with config
-                // TODO
-
-                // Same for regression payloads
-                // TODO
+                let payloads = ul.subtasks[subtask_key]["annotations"]["access"][subtask["resume_from"][i]["id"]]["classification_payloads"];
+                let found_ids = [];
+                for (let j = 0; j < payloads.length; j++) {
+                    let this_id = payloads[j]["class_id"];
+                    if (!(ul.subtasks[subtask_key]["class_ids"].includes(this_id))) {
+                        alert(`Found class id ${this_id} in "resume_from" data but not in "allowed_classes"`);
+                        throw `Found class id ${this_id} in "resume_from" data but not in "allowed_classes"`;
+                    }
+                    found_ids.push(this_id);
+                }
+                for (let j = 0; j < ul.subtasks[subtask_key]["class_ids"].length; j++) {
+                    if (!(found_ids.includes(ul.subtasks[subtask_key]["class_ids"][j]))) {
+                        ul.subtasks[subtask_key]["annotations"]["access"][subtask["resume_from"][i]["id"]]["classification_payloads"].push(
+                            {
+                                "class_id": ul.subtasks[subtask_key]["class_ids"][j],
+                                "confidence": 0.0
+                            }
+                        )
+                    }
+                }
             }
         }
     }

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export const ULABEL_VERSION = "0.4.12";
+export const ULABEL_VERSION = "0.4.13";


### PR DESCRIPTION
# Allow Incomplete Payloads on Import

## Description

- ULabel now allows for classification payloads without items for certain classes, and just assumes that omitted classes have a confidence of zero

## PR Checklist

- [x] Merged latest main
- [x] Version number in `package.json` has been bumped since last release
- [x] Version numbers match between package `package.json` and `src/version.js`
- [x] Ran `npm install` and `npm run build` AFTER bumping the version number
- [x] Updated documentation if necessary (currently just in `api_spec.md`)
- [x] Added changes to `changelog.md`

## Breaking API Changes

None.
