### PR TITLE
Fix Frame Set Annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 ulabel_local/py-dbapi/dbapi/__pycache__
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 ulabel_local/py-dbapi/dbapi/__pycache__
-.vscode

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented here.
 
 Nothing yet.
 
+## [0.4.17] - September 29, 2021
+
+- Fixed an issue with setting annotations at the frame/global level.
+
 ## [0.4.16] - August 27, 2021
 
 - Provides an example of how users can be requested to annotate just a window within an image

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -17319,7 +17319,7 @@ class ULabel {
             subtask = this.state["current_subtask"];
         }
         // No need to rebuild contianing box for image-level annotation types.
-        if (this.subtasks[subtask]["annotations"]["access"]["spatial_type"] in NONSPATIAL_MODES) {
+        if (NONSPATIAL_MODES.includes(this.subtasks[subtask]["annotations"]["access"][actid]["spatial_type"])) {
             return;
         }
         let init_pt = this.subtasks[subtask]["annotations"]["access"][actid]["spatial_payload"][0];

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -13812,7 +13812,7 @@ const COLORS = [
 
 
 ;// CONCATENATED MODULE: ./src/version.js
-const ULABEL_VERSION = "0.4.16";
+const ULABEL_VERSION = "0.4.17";
 ;// CONCATENATED MODULE: ./src/index.js
 /*
 Uncertain Labeling Tool
@@ -17317,6 +17317,10 @@ class ULabel {
     rebuild_containing_box(actid, ignore_final=false, subtask=null) {
         if (subtask == null) {
             subtask = this.state["current_subtask"];
+        }
+        // No need to rebuild contianing box for image-level annotation types.
+        if (this.subtasks[subtask]["annotations"]["access"]["spatial_type"] in ["whole-image", "global"]) {
+            return;
         }
         let init_pt = this.subtasks[subtask]["annotations"]["access"][actid]["spatial_payload"][0];
         this.subtasks[subtask]["annotations"]["access"][actid]["containing_box"] = {

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -17319,7 +17319,7 @@ class ULabel {
             subtask = this.state["current_subtask"];
         }
         // No need to rebuild contianing box for image-level annotation types.
-        if (this.subtasks[subtask]["annotations"]["access"]["spatial_type"] in ["whole-image", "global"]) {
+        if (this.subtasks[subtask]["annotations"]["access"]["spatial_type"] in NONSPATIAL_MODES) {
             return;
         }
         let init_pt = this.subtasks[subtask]["annotations"]["access"][actid]["spatial_payload"][0];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "ulabel",
-  "version": "0.4.16",
+  "version": "0.4.76",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.4.16",
+      "name": "ulabel",
+      "version": "0.4.76",
       "license": "MIT",
       "dependencies": {
         "jquery": "^3.5.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ulabel",
   "description": "An image annotation tool.",
-  "version": "0.4.16",
+  "version": "0.4.76",
   "main": "index.js",
   "module": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -3517,7 +3517,7 @@ export class ULabel {
             subtask = this.state["current_subtask"];
         }
         // No need to rebuild contianing box for image-level annotation types.
-        if (this.subtasks[subtask]["annotations"]["access"]["spatial_type"] in NONSPATIAL_MODES) {
+        if (NONSPATIAL_MODES.includes(this.subtasks[subtask]["annotations"]["access"][actid]["spatial_type"])) {
             return;
         }
         let init_pt = this.subtasks[subtask]["annotations"]["access"][actid]["spatial_payload"][0];

--- a/src/index.js
+++ b/src/index.js
@@ -3517,7 +3517,7 @@ export class ULabel {
             subtask = this.state["current_subtask"];
         }
         // No need to rebuild contianing box for image-level annotation types.
-        if (this.subtasks[subtask]["annotations"]["access"]["spatial_type"] in ["whole-image", "global"]) {
+        if (this.subtasks[subtask]["annotations"]["access"]["spatial_type"] in NONSPATIAL_MODES) {
             return;
         }
         let init_pt = this.subtasks[subtask]["annotations"]["access"][actid]["spatial_payload"][0];

--- a/src/index.js
+++ b/src/index.js
@@ -3516,7 +3516,7 @@ export class ULabel {
         if (subtask == null) {
             subtask = this.state["current_subtask"];
         }
-        // No need to rebuild contianing box for image-level annotation types.
+        // No need to rebuild containing box for image-level annotation types.
         if (NONSPATIAL_MODES.includes(this.subtasks[subtask]["annotations"]["access"][actid]["spatial_type"])) {
             return;
         }

--- a/src/index.js
+++ b/src/index.js
@@ -3516,6 +3516,10 @@ export class ULabel {
         if (subtask == null) {
             subtask = this.state["current_subtask"];
         }
+        // No need to rebuild contianing box for image-level annotation types.
+        if (this.subtasks[subtask]["annotations"]["access"]["spatial_type"] in ["whole-image", "global"]) {
+            return;
+        }
         let init_pt = this.subtasks[subtask]["annotations"]["access"][actid]["spatial_payload"][0];
         this.subtasks[subtask]["annotations"]["access"][actid]["containing_box"] = {
             "tlx": init_pt[0],

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export const ULABEL_VERSION = "0.4.16";
+export const ULABEL_VERSION = "0.4.17";


### PR DESCRIPTION
# Fix Frame Set Annotations

## Description
Calling set annotations assumed a `spatial_payload` exists when that's not the case for frame or global annotations.
Added a check for this.

## PR Checklist

- [X] Merged latest main
- [X] Version number in `package.json` has been bumped since last release
- [X] Version numbers match between package `package.json` and `src/version.js`
- [X] Ran `npm install` and `npm run build` AFTER bumping the version number
- [X] Updated documentation if necessary (currently just in `api_spec.md`)
- [X] Added changes to `changelog.md`

## Breaking API Changes
None
