### PR TITLE
Better keypoint slider

### DIFF
--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -11701,7 +11701,12 @@ var Configuration = /** @class */ (function () {
             AllowedToolboxItem.AnnotationID,
             AllowedToolboxItem.RecolorActive,
             AllowedToolboxItem.ClassCounter,
-            [AllowedToolboxItem.KeypointSlider, [annotation_operators_1.filter_low, annotation_operators_1.get_annotation_confidence, annotation_operators_1.mark_deprecated]]
+            [AllowedToolboxItem.KeypointSlider, {
+                    "name": "Fliter Low Confidence",
+                    "filter_function": annotation_operators_1.filter_low,
+                    "confidence_function": annotation_operators_1.get_annotation_confidence,
+                    "mark_deprecated": annotation_operators_1.mark_deprecated
+                }]
         ];
     }
     Configuration.prototype.create_toolbox = function (ulabel, toolbox_item_order) {
@@ -19927,12 +19932,13 @@ var KeypointSliderItem = /** @class */ (function (_super) {
     //the first function is how to filter the annotations
     //the second is how to get the particular confidence
     //the third is how to mark the annotations deprecated
-    function KeypointSliderItem(ulabel, function_array) {
+    function KeypointSliderItem(ulabel, args_dictionary) {
         var _this = _super.call(this) || this;
         _this.inner_HTML = "<p class=\"tb-header\">Keypoint Slider</p>";
-        _this.filter_function = function_array[0];
-        _this.get_confidence = function_array[1];
-        _this.mark_deprecated = function_array[2];
+        _this.name = args_dictionary.name;
+        var filter_function = args_dictionary.filter_function;
+        var get_confidence = args_dictionary.confidence_function;
+        var mark_deprecated = args_dictionary.mark_deprecated;
         $(document).on("input", "#keypoint-slider", function (e) {
             var current_subtask_key = ulabel.state["current_subtask"];
             var current_subtask = ulabel.subtasks[current_subtask_key];
@@ -19941,19 +19947,19 @@ var KeypointSliderItem = /** @class */ (function (_super) {
             var filter_value = e.currentTarget.value / 100;
             for (var i in current_subtask.annotations.ordering) {
                 var current_annotation = current_subtask.annotations.access[current_subtask.annotations.ordering[i]];
-                var current_confidence = _this.get_confidence(current_annotation);
-                var deprecate = _this.filter_function(current_confidence, filter_value);
+                var current_confidence = get_confidence(current_annotation);
+                var deprecate = filter_function(current_confidence, filter_value);
                 console.log(deprecate);
                 if (deprecate == null)
                     return;
-                _this.mark_deprecated(current_annotation, deprecate);
+                mark_deprecated(current_annotation, deprecate);
             }
             ulabel.redraw_all_annotations(null, null, false);
         });
         return _this;
     }
     KeypointSliderItem.prototype.get_html = function () {
-        return "\n        <div class=\"keypoint-slider\">\n            <p class=\"tb-header\">Keypoint Slider</p>\n            <div class=\"keypoint-slider-holder\">\n                <input type=\"range\" id=\"keypoint-slider\">\n                <label for=\"keypoint-slider\" id=\"keypoint-slider-label\">50%</label>\n            </div>\n        </div>\n        ";
+        return "\n        <div class=\"keypoint-slider\">\n            <p class=\"tb-header\">".concat(this.name, "</p>\n            <div class=\"keypoint-slider-holder\">\n                <input type=\"range\" id=\"keypoint-slider\">\n                <label for=\"keypoint-slider\" id=\"keypoint-slider-label\">50%</label>\n            </div>\n        </div>\n        ");
     };
     return KeypointSliderItem;
 }(ToolboxItem));

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -32,7 +32,12 @@ var Configuration = /** @class */ (function () {
             AllowedToolboxItem.AnnotationID,
             AllowedToolboxItem.RecolorActive,
             AllowedToolboxItem.ClassCounter,
-            [AllowedToolboxItem.KeypointSlider, [annotation_operators_1.filter_low, annotation_operators_1.get_annotation_confidence, annotation_operators_1.mark_deprecated]]
+            [AllowedToolboxItem.KeypointSlider, {
+                    "name": "Fliter Low Confidence",
+                    "filter_function": annotation_operators_1.filter_low,
+                    "confidence_function": annotation_operators_1.get_annotation_confidence,
+                    "mark_deprecated": annotation_operators_1.mark_deprecated
+                }]
         ];
     }
     Configuration.prototype.create_toolbox = function (ulabel, toolbox_item_order) {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -31,7 +31,12 @@ export class Configuration {
         AllowedToolboxItem.AnnotationID,
         AllowedToolboxItem.RecolorActive,
         AllowedToolboxItem.ClassCounter,
-        [AllowedToolboxItem.KeypointSlider, [filter_low, get_annotation_confidence, mark_deprecated]]
+        [AllowedToolboxItem.KeypointSlider, {
+            "name": "Fliter Low Confidence",
+            "filter_function": filter_low, 
+            "confidence_function": get_annotation_confidence, 
+            "mark_deprecated": mark_deprecated
+        }]
     ]
 
     public static default_keybinds: {[key: string]: string} = {

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -458,12 +458,13 @@ var KeypointSliderItem = /** @class */ (function (_super) {
     //the first function is how to filter the annotations
     //the second is how to get the particular confidence
     //the third is how to mark the annotations deprecated
-    function KeypointSliderItem(ulabel, function_array) {
+    function KeypointSliderItem(ulabel, args_dictionary) {
         var _this = _super.call(this) || this;
         _this.inner_HTML = "<p class=\"tb-header\">Keypoint Slider</p>";
-        _this.filter_function = function_array[0];
-        _this.get_confidence = function_array[1];
-        _this.mark_deprecated = function_array[2];
+        _this.name = args_dictionary.name;
+        var filter_function = args_dictionary.filter_function;
+        var get_confidence = args_dictionary.confidence_function;
+        var mark_deprecated = args_dictionary.mark_deprecated;
         $(document).on("input", "#keypoint-slider", function (e) {
             var current_subtask_key = ulabel.state["current_subtask"];
             var current_subtask = ulabel.subtasks[current_subtask_key];
@@ -472,19 +473,19 @@ var KeypointSliderItem = /** @class */ (function (_super) {
             var filter_value = e.currentTarget.value / 100;
             for (var i in current_subtask.annotations.ordering) {
                 var current_annotation = current_subtask.annotations.access[current_subtask.annotations.ordering[i]];
-                var current_confidence = _this.get_confidence(current_annotation);
-                var deprecate = _this.filter_function(current_confidence, filter_value);
+                var current_confidence = get_confidence(current_annotation);
+                var deprecate = filter_function(current_confidence, filter_value);
                 console.log(deprecate);
                 if (deprecate == null)
                     return;
-                _this.mark_deprecated(current_annotation, deprecate);
+                mark_deprecated(current_annotation, deprecate);
             }
             ulabel.redraw_all_annotations(null, null, false);
         });
         return _this;
     }
     KeypointSliderItem.prototype.get_html = function () {
-        return "\n        <div class=\"keypoint-slider\">\n            <p class=\"tb-header\">Keypoint Slider</p>\n            <div class=\"keypoint-slider-holder\">\n                <input type=\"range\" id=\"keypoint-slider\">\n                <label for=\"keypoint-slider\" id=\"keypoint-slider-label\">50%</label>\n            </div>\n        </div>\n        ";
+        return "\n        <div class=\"keypoint-slider\">\n            <p class=\"tb-header\">".concat(this.name, "</p>\n            <div class=\"keypoint-slider-holder\">\n                <input type=\"range\" id=\"keypoint-slider\">\n                <label for=\"keypoint-slider\" id=\"keypoint-slider-label\">50%</label>\n            </div>\n        </div>\n        ");
     };
     return KeypointSliderItem;
 }(ToolboxItem));

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -608,20 +608,19 @@ export class RecolorActiveItem extends ToolboxItem {
 export class KeypointSliderItem extends ToolboxItem {
     public html: string;
     public inner_HTML: string;
-    public filter_function: Function;
-    public get_confidence: Function;
-    public mark_deprecated: Function;
+    public name: string
 
     //function_array must contain three functions
     //the first function is how to filter the annotations
     //the second is how to get the particular confidence
     //the third is how to mark the annotations deprecated
-    constructor(ulabel: ULabel, function_array: Function[]) {
+    constructor(ulabel: ULabel, args_dictionary: {[name: string]: any}) {
         super();
         this.inner_HTML = `<p class="tb-header">Keypoint Slider</p>`;
-        this.filter_function = function_array[0];
-        this.get_confidence = function_array[1];
-        this.mark_deprecated = function_array[2];
+        this.name = args_dictionary.name;
+        let filter_function = args_dictionary.filter_function;
+        let get_confidence = args_dictionary.confidence_function;
+        let mark_deprecated = args_dictionary.mark_deprecated;
         $(document).on("input", "#keypoint-slider", (e) => {
             var current_subtask_key = ulabel.state["current_subtask"];
             var current_subtask = ulabel.subtasks[current_subtask_key];
@@ -631,11 +630,11 @@ export class KeypointSliderItem extends ToolboxItem {
             let filter_value = e.currentTarget.value / 100
             for (let i in current_subtask.annotations.ordering) {
                 let current_annotation = current_subtask.annotations.access[current_subtask.annotations.ordering[i]]
-                let current_confidence = this.get_confidence(current_annotation)
-                let deprecate = this.filter_function(current_confidence, filter_value)
+                let current_confidence = get_confidence(current_annotation)
+                let deprecate = filter_function(current_confidence, filter_value)
                 console.log(deprecate)
                 if (deprecate == null) return;
-                this.mark_deprecated(current_annotation, deprecate)
+                mark_deprecated(current_annotation, deprecate)
             }
             
             ulabel.redraw_all_annotations(null, null, false);
@@ -645,7 +644,7 @@ export class KeypointSliderItem extends ToolboxItem {
     public get_html() {
         return`
         <div class="keypoint-slider">
-            <p class="tb-header">Keypoint Slider</p>
+            <p class="tb-header">${this.name}</p>
             <div class="keypoint-slider-holder">
                 <input type="range" id="keypoint-slider">
                 <label for="keypoint-slider" id="keypoint-slider-label">50%</label>


### PR DESCRIPTION
# Keypoint slider changes

## Description

Now that we have the ability to add multiple instances of the keypoint slider we needed a way to differentiate them, so I added the ability to pass in a name attribute to the keypoint slider toolbox item.

## PR Checklist

- [ ] Merged latest main
- [ ] Version number in `package.json` has been bumped since last release
- [ ] Version numbers match between package `package.json` and `src/version.js`
- [ ] Ran `npm install` and `npm run build` AFTER bumping the version number
- [ ] Updated documentation if necessary (currently just in `api_spec.md`)
- [ ] Added changes to `changelog.md`

## Breaking API Changes

none
