### PR TITLE
another deprecation fix

### DIFF
--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -20071,8 +20071,11 @@ var KeypointSliderItem = /** @class */ (function (_super) {
             //if the parent id exists and is deprecated, then assume that it was human deprecated
             if (parent_id != null) {
                 var parent_annotation = current_subtask.annotations.access[parent_id];
-                if (parent_annotation.deprecated) {
-                    parent_annotation.human_deprecated = true;
+                //check if the parent annotation exists
+                if (parent_annotation != null) {
+                    if (parent_annotation.deprecated) {
+                        parent_annotation.human_deprecated = true;
+                    }
                 }
             }
         }

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -583,8 +583,11 @@ var KeypointSliderItem = /** @class */ (function (_super) {
             //if the parent id exists and is deprecated, then assume that it was human deprecated
             if (parent_id != null) {
                 var parent_annotation = current_subtask.annotations.access[parent_id];
-                if (parent_annotation.deprecated) {
-                    parent_annotation.human_deprecated = true;
+                //check if the parent annotation exists
+                if (parent_annotation != null) {
+                    if (parent_annotation.deprecated) {
+                        parent_annotation.human_deprecated = true;
+                    }
                 }
             }
         }

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -780,9 +780,15 @@ export class KeypointSliderItem extends ToolboxItem {
             //if the parent id exists and is deprecated, then assume that it was human deprecated
             if (parent_id != null) {
                 let parent_annotation = current_subtask.annotations.access[parent_id]
-                if (parent_annotation.deprecated) {
-                    parent_annotation.human_deprecated = true
+
+                //check if the parent annotation exists
+                if (parent_annotation != null) {
+                    
+                    if (parent_annotation.deprecated) {
+                        parent_annotation.human_deprecated = true
+                    }
                 }
+
             }
         }
     }


### PR DESCRIPTION
# Fix check_for_human_deprecated

## Description

If an annotation had a parent id that wasn't one of the annotations in the current subtask then check_for_human_deprecated would break. Should be fixed

## PR Checklist

- [ ] Merged latest main
- [ ] Version number in `package.json` has been bumped since last release
- [ ] Version numbers match between package `package.json` and `src/version.js`
- [ ] Ran `npm install` and `npm run build` AFTER bumping the version number
- [ ] Updated documentation if necessary (currently just in `api_spec.md`)
- [ ] Added changes to `changelog.md`

## Breaking API Changes

none
