### PR TITLE
make sure eq isn't null in get_nearest_point_on_segment

### DIFF
--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -11928,6 +11928,9 @@ var GeometricUtils = /** @class */ (function () {
     //   return the point on the segment that is closest to the reference point, as well
     //   as the distance away
     GeometricUtils.get_nearest_point_on_segment = function (ref_x, ref_y, eq, kp1, kp2) {
+        //check to make sure eq exists
+        if (eq == null)
+            return null;
         // For convenience
         var a = eq["a"];
         var b = eq["b"];

--- a/src/geometric_utils.js
+++ b/src/geometric_utils.js
@@ -40,6 +40,9 @@ var GeometricUtils = /** @class */ (function () {
     //   return the point on the segment that is closest to the reference point, as well
     //   as the distance away
     GeometricUtils.get_nearest_point_on_segment = function (ref_x, ref_y, eq, kp1, kp2) {
+        //check to make sure eq exists
+        if (eq == null)
+            return null;
         // For convenience
         var a = eq["a"];
         var b = eq["b"];

--- a/src/geometric_utils.ts
+++ b/src/geometric_utils.ts
@@ -43,6 +43,9 @@ export class GeometricUtils {
     //   return the point on the segment that is closest to the reference point, as well
     //   as the distance away
     public static get_nearest_point_on_segment(ref_x: number, ref_y: number, eq: object, kp1: Array<number>, kp2: Array<number>): object {
+        //check to make sure eq exists
+        if (eq == null) return null
+
         // For convenience
         const a = eq["a"];
         const b = eq["b"];


### PR DESCRIPTION
# make sure eq isn't null in get_nearest_point_on_segment

## Description

get_line_equation_through_points returns null when its given the same two points. When that happens get_nearest_point_on_segment would then receive a null object and we'd get an error. This just checks to make sure that the line object we receive isn't null

## PR Checklist

- [ ] Merged latest main
- [ ] Version number in `package.json` has been bumped since last release
- [ ] Version numbers match between package `package.json` and `src/version.js`
- [ ] Ran `npm install` and `npm run build` AFTER bumping the version number
- [ ] Updated documentation if necessary (currently just in `api_spec.md`)
- [ ] Added changes to `changelog.md`

## Breaking API Changes

none
