### PR TITLE
fixed illegible text on keypoint slider label in nightmode

### DIFF
--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -14038,9 +14038,13 @@ div#${prntid} div.keypoint-slider div.keypoint-slider-holder{
    padding: 8px;
 }
 
-div#${prntid} #keypoint-slider-label {
+div#${prntid} .keypoint-slider-label {
    position: relative;
    bottom: 3px;
+}
+
+div#${prntid}.ulabel-night .keypoint-slider-label {
+   color: white;
 }
 
 div#${prntid} div.zpcont {

--- a/src/blobs.js
+++ b/src/blobs.js
@@ -1917,9 +1917,13 @@ div#${prntid} div.keypoint-slider div.keypoint-slider-holder{
    padding: 8px;
 }
 
-div#${prntid} #keypoint-slider-label {
+div#${prntid} .keypoint-slider-label {
    position: relative;
    bottom: 3px;
+}
+
+div#${prntid}.ulabel-night .keypoint-slider-label {
+   color: white;
 }
 
 div#${prntid} div.zpcont {


### PR DESCRIPTION
# Couldn't read the keypoint slider label in nightmode

## Description

Once again we seem to have broken the keypoint slider label's css. Since the text was defaulting to black it was almost impossible to read. 

## PR Checklist

- [ ] Merged latest main
- [ ] Version number in `package.json` has been bumped since last release
- [ ] Version numbers match between package `package.json` and `src/version.js`
- [ ] Ran `npm install` and `npm run build` AFTER bumping the version number
- [ ] Updated documentation if necessary (currently just in `api_spec.md`)
- [ ] Added changes to `changelog.md`

## Breaking API Changes

none
