### PR TITLE
New configuration

### DIFF
--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -11714,14 +11714,12 @@ var Configuration = /** @class */ (function () {
                     "default_value": 0.05
                 }]
         ];
-        this.config = {
-            "default_keybinds": {
-                "annotation_size_small": "s",
-                "annotation_size_large": "l",
-                "annotation_size_plus": "=",
-                "annotation_size_minus": "-",
-                "annotation_vanish": "v" //The v Key by default
-            },
+        this.default_keybinds = {
+            "annotation_size_small": "s",
+            "annotation_size_large": "l",
+            "annotation_size_plus": "=",
+            "annotation_size_minus": "-",
+            "annotation_vanish": "v" //The v Key by default
         };
         this.modify_config.apply(this, kwargs);
     }
@@ -11734,7 +11732,7 @@ var Configuration = /** @class */ (function () {
         for (var i = 0; i < kwargs.length; i++) {
             //for every key: value pair, overwrite them/add them to the config
             for (var key in kwargs[i]) {
-                this.config[key] = kwargs[i][key];
+                this[key] = kwargs[i][key];
             }
         }
     };
@@ -14730,7 +14728,7 @@ class ULabel {
 
         //grab the default toolbox if one wasn't provided
         if (toolbox_item_order == null) {
-            toolbox_item_order = ulabel.configuration.default_toolbox_item_order
+            toolbox_item_order = ulabel.config.default_toolbox_item_order
         }
 
         //There's no point to having an empty toolbox, so throw an error if the toolbox is empty.
@@ -14758,7 +14756,7 @@ class ULabel {
                 args = toolbox_item_order[i][1]  
             }
 
-            let toolbox_item_class = ulabel.configuration.toolbox_map.get(toolbox_key);
+            let toolbox_item_class = ulabel.config.toolbox_map.get(toolbox_key);
 
             if (args == null) {
                 toolbox_instance_list.push(new toolbox_item_class(ulabel))
@@ -15729,7 +15727,8 @@ class ULabel {
         px_per_px = 1,
         initial_crop = null,
         initial_line_size = 4,
-        instructions_url = null
+        instructions_url = null,
+        config_data = null
     ) {
         // Unroll safe default arguments
         if (task_meta == null) { task_meta = {}; }
@@ -15762,7 +15761,9 @@ class ULabel {
         // Allow for importing spacing data -- a measure tool would be nice too
         // Much of this is hardcoded defaults, 
         //   some might be offloaded to the constructor eventually...
-        this.config = {
+
+        //create the config and add ulabel dependent data
+        this.config = new configuration.Configuration({
             // Values useful for generating HTML for tool
             // TODO(v1) Make sure these don't conflict with other page elements
             "container_id": container_id,
@@ -15805,11 +15806,12 @@ class ULabel {
             // Passthrough
             "task_meta": task_meta,
             "annotation_meta": annotation_meta
-        };
+        });
 
-        // this.configuration = new Configuration({
-        //     "test": "potatoe"
-        // });
+        //add passed in data to config
+        if (config_data != null) {
+            this.config.modify_config(config_data)
+        }
 
 
         // Useful for the efficient redraw of nonspatial annotations
@@ -15895,9 +15897,7 @@ class ULabel {
         // Add stylesheet
         ULabel.add_style_to_document(this);
 
-        this.configuration = new configuration.Configuration({
-            "test": "potatoe"
-        });
+        
 
         var that = this;
         that.state["current_subtask"] = Object.keys(that.subtasks)[0];

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -11685,6 +11685,10 @@ var AllowedToolboxItem;
 })(AllowedToolboxItem || (AllowedToolboxItem = {}));
 var Configuration = /** @class */ (function () {
     function Configuration() {
+        var kwargs = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            kwargs[_i] = arguments[_i];
+        }
         this.toolbox_map = new Map([
             [AllowedToolboxItem.ModeSelect, toolbox_1.ModeSelectionToolboxItem],
             [AllowedToolboxItem.ZoomPan, toolbox_1.ZoomPanToolboxItem],
@@ -11710,7 +11714,30 @@ var Configuration = /** @class */ (function () {
                     "default_value": 0.05
                 }]
         ];
+        this.config = {
+            "default_keybinds": {
+                "annotation_size_small": "s",
+                "annotation_size_large": "l",
+                "annotation_size_plus": "=",
+                "annotation_size_minus": "-",
+                "annotation_vanish": "v" //The v Key by default
+            },
+        };
+        this.modify_config.apply(this, kwargs);
     }
+    Configuration.prototype.modify_config = function () {
+        var kwargs = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            kwargs[_i] = arguments[_i];
+        }
+        //we don't know how many arguments we'll recieve, so loop through all of the elements in kwargs
+        for (var i = 0; i < kwargs.length; i++) {
+            //for every key: value pair, overwrite them/add them to the config
+            for (var key in kwargs[i]) {
+                this.config[key] = kwargs[i][key];
+            }
+        }
+    };
     Configuration.prototype.create_toolbox = function (ulabel, toolbox_item_order) {
         if (toolbox_item_order === void 0) { toolbox_item_order = this.default_toolbox_item_order; }
         //There's no point to having an empty toolbox, so throw an error if the toolbox is empty.
@@ -11743,13 +11770,6 @@ var Configuration = /** @class */ (function () {
             }
         }
         return toolbox_instance_list;
-    };
-    Configuration.default_keybinds = {
-        "annotation_size_small": "s",
-        "annotation_size_large": "l",
-        "annotation_size_plus": "=",
-        "annotation_size_minus": "-",
-        "annotation_vanish": "v" //The v Key by default
     };
     Configuration.annotation_gradient_default = false;
     return Configuration;
@@ -12114,7 +12134,7 @@ var annotation_operators = __webpack_require__(419);
 // EXTERNAL MODULE: ./src/drawing_utilities.js
 var drawing_utilities = __webpack_require__(848);
 // EXTERNAL MODULE: ./src/configuration.js
-var src_configuration = __webpack_require__(976);
+var configuration = __webpack_require__(976);
 // EXTERNAL MODULE: ./node_modules/jquery/dist/jquery.js
 var jquery = __webpack_require__(755);
 var jquery_default = /*#__PURE__*/__webpack_require__.n(jquery);
@@ -14744,12 +14764,48 @@ class ULabel {
         const images = ULabel.get_images_html(ul);
         const frame_annotation_dialogs = ULabel.get_frame_annotation_dialogs(ul);
 
-        let configuration = new src_configuration.Configuration();
+        //let configuration = new Configuration();
+
+        console.log(ul)
+
+        // let toolbox_item_order = ul.configuration.default_toolbox_item_order;
+
+        // //create the toolbox
+        // if (toolbox_item_order.length == 0) {
+        //     throw new Error("No Toolbox Items Given")
+        // }
+
+        // let toolbox_instance_list = [];
+        // //Go through the items in toolbox_item_order and add their instance to the toolbox instance list
+        // for (let i = 0; i < toolbox_item_order.length; i++) {
+
+        //     let args, toolbox_key;
+
+        //     //If the value of toolbox_item_order[i] is a number then that means the it is one of the 
+        //     //enumerated toolbox items, so set it to the key, otherwise the element must be an array
+        //     //of which the first element of that array must be the enumerated value, and the arguments
+        //     //must be the second value
+        //     if (typeof(toolbox_item_order[i]) == "number") {
+        //         toolbox_key = toolbox_item_order[i]
+        //     } else {
+
+        //         toolbox_key = toolbox_item_order[i][0];
+        //         args = toolbox_item_order[i][1]  
+        //     }
+
+        //     let toolbox_item_class = ul.Configuration.toolbox_map.get(toolbox_key);
+
+        //     if (args == null) {
+        //         toolbox_instance_list.push(new ul.Configuration.toolbox_item_class(ulabel))
+        //     } else {
+        //         toolbox_instance_list.push(new ul.Configuration.toolbox_item_class(ulabel, args))
+        //     }           
+        // }
         
         // const toolbox = configuration.create_toolbox();
         const toolbox = new src_toolbox.Toolbox(
             [],
-            configuration.create_toolbox(ul)
+            ul.configuration.create_toolbox(ul)
         );
 
 
@@ -15775,6 +15831,11 @@ class ULabel {
             "annotation_meta": annotation_meta
         };
 
+        // this.configuration = new Configuration({
+        //     "test": "potatoe"
+        // });
+
+
         // Useful for the efficient redraw of nonspatial annotations
         this.tmp_nonspatial_element_ids = {};
 
@@ -15857,6 +15918,10 @@ class ULabel {
     init(callback) {
         // Add stylesheet
         ULabel.add_style_to_document(this);
+
+        this.configuration = new configuration.Configuration({
+            "test": "potatoe"
+        });
 
         var that = this;
         that.state["current_subtask"] = Object.keys(that.subtasks)[0];
@@ -19723,8 +19788,9 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         var _this = _super.call(this) || this;
         _this.is_vanished = false;
         _this.cached_size = 1.5;
-        _this.keybind_configuration = configuration_1.Configuration.default_keybinds;
         _this.inner_HTML = "<p class=\"tb-header\">Annotation Count</p>";
+        //get default keybinds
+        _this.keybind_configuration = ulabel.config.default_keybinds;
         //event listener for buttons
         $(document).on("click", "a.butt-ann", function (e) {
             var button = $(e.currentTarget);

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -11738,39 +11738,6 @@ var Configuration = /** @class */ (function () {
             }
         }
     };
-    Configuration.prototype.create_toolbox = function (ulabel, toolbox_item_order) {
-        if (toolbox_item_order === void 0) { toolbox_item_order = this.default_toolbox_item_order; }
-        //There's no point to having an empty toolbox, so throw an error if the toolbox is empty.
-        //The toolbox won't actually break if there aren't any items in the toolbox, so if for
-        //whatever reason we want that in the future, then feel free to remove this error.
-        if (toolbox_item_order.length == 0) {
-            throw new Error("No Toolbox Items Given");
-        }
-        var toolbox_instance_list = [];
-        //Go through the items in toolbox_item_order and add their instance to the toolbox instance list
-        for (var i = 0; i < toolbox_item_order.length; i++) {
-            var args = void 0, toolbox_key = void 0;
-            //If the value of toolbox_item_order[i] is a number then that means the it is one of the 
-            //enumerated toolbox items, so set it to the key, otherwise the element must be an array
-            //of which the first element of that array must be the enumerated value, and the arguments
-            //must be the second value
-            if (typeof (toolbox_item_order[i]) == "number") {
-                toolbox_key = toolbox_item_order[i];
-            }
-            else {
-                toolbox_key = toolbox_item_order[i][0];
-                args = toolbox_item_order[i][1];
-            }
-            var toolbox_item_class = this.toolbox_map.get(toolbox_key);
-            if (args == null) {
-                toolbox_instance_list.push(new toolbox_item_class(ulabel));
-            }
-            else {
-                toolbox_instance_list.push(new toolbox_item_class(ulabel, args));
-            }
-        }
-        return toolbox_instance_list;
-    };
     Configuration.annotation_gradient_default = false;
     return Configuration;
 }());
@@ -14759,6 +14726,49 @@ class ULabel {
         return ret;
     }
 
+    static create_toolbox(ulabel, toolbox_item_order = null) {
+
+        //grab the default toolbox if one wasn't provided
+        if (toolbox_item_order == null) {
+            toolbox_item_order = ulabel.configuration.default_toolbox_item_order
+        }
+
+        //There's no point to having an empty toolbox, so throw an error if the toolbox is empty.
+        //The toolbox won't actually break if there aren't any items in the toolbox, so if for
+        //whatever reason we want that in the future, then feel free to remove this error.
+        if (toolbox_item_order.length == 0) {
+            throw new Error("No Toolbox Items Given")
+        }
+
+        let toolbox_instance_list = [];
+        //Go through the items in toolbox_item_order and add their instance to the toolbox instance list
+        for (let i = 0; i < toolbox_item_order.length; i++) {
+
+            let args, toolbox_key;
+
+            //If the value of toolbox_item_order[i] is a number then that means the it is one of the 
+            //enumerated toolbox items, so set it to the key, otherwise the element must be an array
+            //of which the first element of that array must be the enumerated value, and the arguments
+            //must be the second value
+            if (typeof(toolbox_item_order[i]) == "number") {
+                toolbox_key = toolbox_item_order[i]
+            } else {
+
+                toolbox_key = toolbox_item_order[i][0];
+                args = toolbox_item_order[i][1]  
+            }
+
+            let toolbox_item_class = ulabel.configuration.toolbox_map.get(toolbox_key);
+
+            if (args == null) {
+                toolbox_instance_list.push(new toolbox_item_class(ulabel))
+            } else {
+                toolbox_instance_list.push(new toolbox_item_class(ulabel, args))
+            }           
+        }
+
+        return toolbox_instance_list
+    }
 
     static prep_window_html(ul) {
         // Bring image and annotation scaffolding in
@@ -14767,49 +14777,11 @@ class ULabel {
         // const tabs = ULabel.get_toolbox_tabs(ul);
         const images = ULabel.get_images_html(ul);
         const frame_annotation_dialogs = ULabel.get_frame_annotation_dialogs(ul);
-
-        //let configuration = new Configuration();
-
-        console.log(ul)
-
-        // let toolbox_item_order = ul.configuration.default_toolbox_item_order;
-
-        // //create the toolbox
-        // if (toolbox_item_order.length == 0) {
-        //     throw new Error("No Toolbox Items Given")
-        // }
-
-        // let toolbox_instance_list = [];
-        // //Go through the items in toolbox_item_order and add their instance to the toolbox instance list
-        // for (let i = 0; i < toolbox_item_order.length; i++) {
-
-        //     let args, toolbox_key;
-
-        //     //If the value of toolbox_item_order[i] is a number then that means the it is one of the 
-        //     //enumerated toolbox items, so set it to the key, otherwise the element must be an array
-        //     //of which the first element of that array must be the enumerated value, and the arguments
-        //     //must be the second value
-        //     if (typeof(toolbox_item_order[i]) == "number") {
-        //         toolbox_key = toolbox_item_order[i]
-        //     } else {
-
-        //         toolbox_key = toolbox_item_order[i][0];
-        //         args = toolbox_item_order[i][1]  
-        //     }
-
-        //     let toolbox_item_class = ul.Configuration.toolbox_map.get(toolbox_key);
-
-        //     if (args == null) {
-        //         toolbox_instance_list.push(new ul.Configuration.toolbox_item_class(ulabel))
-        //     } else {
-        //         toolbox_instance_list.push(new ul.Configuration.toolbox_item_class(ulabel, args))
-        //     }           
-        // }
         
         // const toolbox = configuration.create_toolbox();
         const toolbox = new src_toolbox.Toolbox(
             [],
-            ul.configuration.create_toolbox(ul)
+            ULabel.create_toolbox(ul)
         );
 
 

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -68,39 +68,6 @@ var Configuration = /** @class */ (function () {
             }
         }
     };
-    Configuration.prototype.create_toolbox = function (ulabel, toolbox_item_order) {
-        if (toolbox_item_order === void 0) { toolbox_item_order = this.default_toolbox_item_order; }
-        //There's no point to having an empty toolbox, so throw an error if the toolbox is empty.
-        //The toolbox won't actually break if there aren't any items in the toolbox, so if for
-        //whatever reason we want that in the future, then feel free to remove this error.
-        if (toolbox_item_order.length == 0) {
-            throw new Error("No Toolbox Items Given");
-        }
-        var toolbox_instance_list = [];
-        //Go through the items in toolbox_item_order and add their instance to the toolbox instance list
-        for (var i = 0; i < toolbox_item_order.length; i++) {
-            var args = void 0, toolbox_key = void 0;
-            //If the value of toolbox_item_order[i] is a number then that means the it is one of the 
-            //enumerated toolbox items, so set it to the key, otherwise the element must be an array
-            //of which the first element of that array must be the enumerated value, and the arguments
-            //must be the second value
-            if (typeof (toolbox_item_order[i]) == "number") {
-                toolbox_key = toolbox_item_order[i];
-            }
-            else {
-                toolbox_key = toolbox_item_order[i][0];
-                args = toolbox_item_order[i][1];
-            }
-            var toolbox_item_class = this.toolbox_map.get(toolbox_key);
-            if (args == null) {
-                toolbox_instance_list.push(new toolbox_item_class(ulabel));
-            }
-            else {
-                toolbox_instance_list.push(new toolbox_item_class(ulabel, args));
-            }
-        }
-        return toolbox_instance_list;
-    };
     Configuration.annotation_gradient_default = false;
     return Configuration;
 }());

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -44,14 +44,12 @@ var Configuration = /** @class */ (function () {
                     "default_value": 0.05
                 }]
         ];
-        this.config = {
-            "default_keybinds": {
-                "annotation_size_small": "s",
-                "annotation_size_large": "l",
-                "annotation_size_plus": "=",
-                "annotation_size_minus": "-",
-                "annotation_vanish": "v" //The v Key by default
-            },
+        this.default_keybinds = {
+            "annotation_size_small": "s",
+            "annotation_size_large": "l",
+            "annotation_size_plus": "=",
+            "annotation_size_minus": "-",
+            "annotation_vanish": "v" //The v Key by default
         };
         this.modify_config.apply(this, kwargs);
     }
@@ -64,7 +62,7 @@ var Configuration = /** @class */ (function () {
         for (var i = 0; i < kwargs.length; i++) {
             //for every key: value pair, overwrite them/add them to the config
             for (var key in kwargs[i]) {
-                this.config[key] = kwargs[i][key];
+                this[key] = kwargs[i][key];
             }
         }
     };

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -15,6 +15,10 @@ var AllowedToolboxItem;
 })(AllowedToolboxItem || (AllowedToolboxItem = {}));
 var Configuration = /** @class */ (function () {
     function Configuration() {
+        var kwargs = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            kwargs[_i] = arguments[_i];
+        }
         this.toolbox_map = new Map([
             [AllowedToolboxItem.ModeSelect, toolbox_1.ModeSelectionToolboxItem],
             [AllowedToolboxItem.ZoomPan, toolbox_1.ZoomPanToolboxItem],
@@ -40,7 +44,30 @@ var Configuration = /** @class */ (function () {
                     "default_value": 0.05
                 }]
         ];
+        this.config = {
+            "default_keybinds": {
+                "annotation_size_small": "s",
+                "annotation_size_large": "l",
+                "annotation_size_plus": "=",
+                "annotation_size_minus": "-",
+                "annotation_vanish": "v" //The v Key by default
+            },
+        };
+        this.modify_config.apply(this, kwargs);
     }
+    Configuration.prototype.modify_config = function () {
+        var kwargs = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            kwargs[_i] = arguments[_i];
+        }
+        //we don't know how many arguments we'll recieve, so loop through all of the elements in kwargs
+        for (var i = 0; i < kwargs.length; i++) {
+            //for every key: value pair, overwrite them/add them to the config
+            for (var key in kwargs[i]) {
+                this.config[key] = kwargs[i][key];
+            }
+        }
+    };
     Configuration.prototype.create_toolbox = function (ulabel, toolbox_item_order) {
         if (toolbox_item_order === void 0) { toolbox_item_order = this.default_toolbox_item_order; }
         //There's no point to having an empty toolbox, so throw an error if the toolbox is empty.
@@ -73,13 +100,6 @@ var Configuration = /** @class */ (function () {
             }
         }
         return toolbox_instance_list;
-    };
-    Configuration.default_keybinds = {
-        "annotation_size_small": "s",
-        "annotation_size_large": "l",
-        "annotation_size_plus": "=",
-        "annotation_size_minus": "-",
-        "annotation_vanish": "v" //The v Key by default
     };
     Configuration.annotation_gradient_default = false;
     return Configuration;

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -45,7 +45,7 @@ export class Configuration {
         "annotation_size_plus": "=",   //The = Key by default
         "annotation_size_minus": "-",  //The - Key by default
         "annotation_vanish": "v"      //The v Key by default
-        }
+    }
 
     public static annotation_gradient_default: boolean = false;
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -40,17 +40,35 @@ export class Configuration {
         }]
     ]
 
-    public static default_keybinds: {[key: string]: string} = {
-        "annotation_size_small": "s", //The s Key by default
-        "annotation_size_large": "l", //The l Key by default
-        "annotation_size_plus": "=",   //The = Key by default
-        "annotation_size_minus": "-",  //The - Key by default
-        "annotation_vanish": "v"      //The v Key by default
+    public config: {[key: string]: unknown} = {
+
+        "default_keybinds": {
+            "annotation_size_small": "s", //The s Key by default
+            "annotation_size_large": "l", //The l Key by default
+            "annotation_size_plus": "=",   //The = Key by default
+            "annotation_size_minus": "-",  //The - Key by default
+            "annotation_vanish": "v"      //The v Key by default
+        },
+
     }
 
     public static annotation_gradient_default: boolean = false;
 
-    constructor() {}
+    constructor(...kwargs: {[key: string]: unknown}[]) {
+        this.modify_config(...kwargs)
+    }
+
+    public modify_config(...kwargs: {[key: string]: unknown}[]) {
+
+        //we don't know how many arguments we'll recieve, so loop through all of the elements in kwargs
+        for (let i = 0; i < kwargs.length; i++) {
+
+            //for every key: value pair, overwrite them/add them to the config
+            for (let key in kwargs[i]) {
+                this.config[key] = kwargs[i][key]
+            }
+        }
+    }
 
     public create_toolbox(ulabel: ULabel, toolbox_item_order = this.default_toolbox_item_order) {
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -39,17 +39,13 @@ export class Configuration {
         }]
     ]
 
-    public config: {[key: string]: unknown} = {
-
-        "default_keybinds": {
+    public default_keybinds = {
             "annotation_size_small": "s", //The s Key by default
             "annotation_size_large": "l", //The l Key by default
             "annotation_size_plus": "=",   //The = Key by default
             "annotation_size_minus": "-",  //The - Key by default
             "annotation_vanish": "v"      //The v Key by default
-        },
-
-    }
+        }
 
     public static annotation_gradient_default: boolean = false;
 
@@ -64,7 +60,7 @@ export class Configuration {
 
             //for every key: value pair, overwrite them/add them to the config
             for (let key in kwargs[i]) {
-                this.config[key] = kwargs[i][key]
+                this[key] = kwargs[i][key]
             }
         }
     }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,4 +1,3 @@
-import { ULabel } from "..";
 import { ModeSelectionToolboxItem, ZoomPanToolboxItem, AnnotationIDToolboxItem, ClassCounterToolboxItem, AnnotationResizeItem, RecolorActiveItem, KeypointSliderItem } from "./toolbox"
 import { get_annotation_confidence, mark_deprecated, filter_low } from "./annotation_operators";
 
@@ -24,7 +23,7 @@ export class Configuration {
     ]);
     
     //Change the order of the toolbox items here to change the order they show up in the toolbox
-    public default_toolbox_item_order: any[] = [
+    public default_toolbox_item_order: unknown[] = [
         AllowedToolboxItem.ModeSelect,
         AllowedToolboxItem.ZoomPan,
         AllowedToolboxItem.AnnotationResize,
@@ -68,44 +67,5 @@ export class Configuration {
                 this.config[key] = kwargs[i][key]
             }
         }
-    }
-
-    public create_toolbox(ulabel: ULabel, toolbox_item_order = this.default_toolbox_item_order) {
-
-        //There's no point to having an empty toolbox, so throw an error if the toolbox is empty.
-        //The toolbox won't actually break if there aren't any items in the toolbox, so if for
-        //whatever reason we want that in the future, then feel free to remove this error.
-        if (toolbox_item_order.length == 0) {
-            throw new Error("No Toolbox Items Given")
-        }
-
-        let toolbox_instance_list = [];
-        //Go through the items in toolbox_item_order and add their instance to the toolbox instance list
-        for (let i = 0; i < toolbox_item_order.length; i++) {
-
-            let args, toolbox_key;
-
-            //If the value of toolbox_item_order[i] is a number then that means the it is one of the 
-            //enumerated toolbox items, so set it to the key, otherwise the element must be an array
-            //of which the first element of that array must be the enumerated value, and the arguments
-            //must be the second value
-            if (typeof(toolbox_item_order[i]) == "number") {
-                toolbox_key = toolbox_item_order[i]
-            } else {
-
-                toolbox_key = toolbox_item_order[i][0];
-                args = toolbox_item_order[i][1]  
-            }
-
-            let toolbox_item_class = this.toolbox_map.get(toolbox_key);
-
-            if (args == null) {
-                toolbox_instance_list.push(new toolbox_item_class(ulabel))
-            } else {
-                toolbox_instance_list.push(new toolbox_item_class(ulabel, args))
-            }           
-        }
-
-        return toolbox_instance_list
     }
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -40,11 +40,11 @@ export class Configuration {
     ]
 
     public default_keybinds = {
-            "annotation_size_small": "s", //The s Key by default
-            "annotation_size_large": "l", //The l Key by default
-            "annotation_size_plus": "=",   //The = Key by default
-            "annotation_size_minus": "-",  //The - Key by default
-            "annotation_vanish": "v"      //The v Key by default
+        "annotation_size_small": "s", //The s Key by default
+        "annotation_size_large": "l", //The l Key by default
+        "annotation_size_plus": "=",   //The = Key by default
+        "annotation_size_minus": "-",  //The - Key by default
+        "annotation_vanish": "v"      //The v Key by default
         }
 
     public static annotation_gradient_default: boolean = false;

--- a/src/index.js
+++ b/src/index.js
@@ -235,12 +235,48 @@ export class ULabel {
         const images = ULabel.get_images_html(ul);
         const frame_annotation_dialogs = ULabel.get_frame_annotation_dialogs(ul);
 
-        let configuration = new Configuration();
+        //let configuration = new Configuration();
+
+        console.log(ul)
+
+        // let toolbox_item_order = ul.configuration.default_toolbox_item_order;
+
+        // //create the toolbox
+        // if (toolbox_item_order.length == 0) {
+        //     throw new Error("No Toolbox Items Given")
+        // }
+
+        // let toolbox_instance_list = [];
+        // //Go through the items in toolbox_item_order and add their instance to the toolbox instance list
+        // for (let i = 0; i < toolbox_item_order.length; i++) {
+
+        //     let args, toolbox_key;
+
+        //     //If the value of toolbox_item_order[i] is a number then that means the it is one of the 
+        //     //enumerated toolbox items, so set it to the key, otherwise the element must be an array
+        //     //of which the first element of that array must be the enumerated value, and the arguments
+        //     //must be the second value
+        //     if (typeof(toolbox_item_order[i]) == "number") {
+        //         toolbox_key = toolbox_item_order[i]
+        //     } else {
+
+        //         toolbox_key = toolbox_item_order[i][0];
+        //         args = toolbox_item_order[i][1]  
+        //     }
+
+        //     let toolbox_item_class = ul.Configuration.toolbox_map.get(toolbox_key);
+
+        //     if (args == null) {
+        //         toolbox_instance_list.push(new ul.Configuration.toolbox_item_class(ulabel))
+        //     } else {
+        //         toolbox_instance_list.push(new ul.Configuration.toolbox_item_class(ulabel, args))
+        //     }           
+        // }
         
         // const toolbox = configuration.create_toolbox();
         const toolbox = new Toolbox(
             [],
-            configuration.create_toolbox(ul)
+            ul.configuration.create_toolbox(ul)
         );
 
 
@@ -1266,6 +1302,11 @@ export class ULabel {
             "annotation_meta": annotation_meta
         };
 
+        // this.configuration = new Configuration({
+        //     "test": "potatoe"
+        // });
+
+
         // Useful for the efficient redraw of nonspatial annotations
         this.tmp_nonspatial_element_ids = {};
 
@@ -1348,6 +1389,10 @@ export class ULabel {
     init(callback) {
         // Add stylesheet
         ULabel.add_style_to_document(this);
+
+        this.configuration = new Configuration({
+            "test": "potatoe"
+        });
 
         var that = this;
         that.state["current_subtask"] = Object.keys(that.subtasks)[0];

--- a/src/index.js
+++ b/src/index.js
@@ -230,7 +230,7 @@ export class ULabel {
 
         //grab the default toolbox if one wasn't provided
         if (toolbox_item_order == null) {
-            toolbox_item_order = ulabel.configuration.default_toolbox_item_order
+            toolbox_item_order = ulabel.config.default_toolbox_item_order
         }
 
         //There's no point to having an empty toolbox, so throw an error if the toolbox is empty.
@@ -258,7 +258,7 @@ export class ULabel {
                 args = toolbox_item_order[i][1]  
             }
 
-            let toolbox_item_class = ulabel.configuration.toolbox_map.get(toolbox_key);
+            let toolbox_item_class = ulabel.config.toolbox_map.get(toolbox_key);
 
             if (args == null) {
                 toolbox_instance_list.push(new toolbox_item_class(ulabel))
@@ -1229,7 +1229,8 @@ export class ULabel {
         px_per_px = 1,
         initial_crop = null,
         initial_line_size = 4,
-        instructions_url = null
+        instructions_url = null,
+        config_data = null
     ) {
         // Unroll safe default arguments
         if (task_meta == null) { task_meta = {}; }
@@ -1262,7 +1263,9 @@ export class ULabel {
         // Allow for importing spacing data -- a measure tool would be nice too
         // Much of this is hardcoded defaults, 
         //   some might be offloaded to the constructor eventually...
-        this.config = {
+
+        //create the config and add ulabel dependent data
+        this.config = new Configuration({
             // Values useful for generating HTML for tool
             // TODO(v1) Make sure these don't conflict with other page elements
             "container_id": container_id,
@@ -1305,11 +1308,12 @@ export class ULabel {
             // Passthrough
             "task_meta": task_meta,
             "annotation_meta": annotation_meta
-        };
+        });
 
-        // this.configuration = new Configuration({
-        //     "test": "potatoe"
-        // });
+        //add passed in data to config
+        if (config_data != null) {
+            this.config.modify_config(config_data)
+        }
 
 
         // Useful for the efficient redraw of nonspatial annotations
@@ -1395,9 +1399,7 @@ export class ULabel {
         // Add stylesheet
         ULabel.add_style_to_document(this);
 
-        this.configuration = new Configuration({
-            "test": "potatoe"
-        });
+        
 
         var that = this;
         that.state["current_subtask"] = Object.keys(that.subtasks)[0];

--- a/src/index.js
+++ b/src/index.js
@@ -226,6 +226,49 @@ export class ULabel {
         return ret;
     }
 
+    static create_toolbox(ulabel, toolbox_item_order = null) {
+
+        //grab the default toolbox if one wasn't provided
+        if (toolbox_item_order == null) {
+            toolbox_item_order = ulabel.configuration.default_toolbox_item_order
+        }
+
+        //There's no point to having an empty toolbox, so throw an error if the toolbox is empty.
+        //The toolbox won't actually break if there aren't any items in the toolbox, so if for
+        //whatever reason we want that in the future, then feel free to remove this error.
+        if (toolbox_item_order.length == 0) {
+            throw new Error("No Toolbox Items Given")
+        }
+
+        let toolbox_instance_list = [];
+        //Go through the items in toolbox_item_order and add their instance to the toolbox instance list
+        for (let i = 0; i < toolbox_item_order.length; i++) {
+
+            let args, toolbox_key;
+
+            //If the value of toolbox_item_order[i] is a number then that means the it is one of the 
+            //enumerated toolbox items, so set it to the key, otherwise the element must be an array
+            //of which the first element of that array must be the enumerated value, and the arguments
+            //must be the second value
+            if (typeof(toolbox_item_order[i]) == "number") {
+                toolbox_key = toolbox_item_order[i]
+            } else {
+
+                toolbox_key = toolbox_item_order[i][0];
+                args = toolbox_item_order[i][1]  
+            }
+
+            let toolbox_item_class = ulabel.configuration.toolbox_map.get(toolbox_key);
+
+            if (args == null) {
+                toolbox_instance_list.push(new toolbox_item_class(ulabel))
+            } else {
+                toolbox_instance_list.push(new toolbox_item_class(ulabel, args))
+            }           
+        }
+
+        return toolbox_instance_list
+    }
 
     static prep_window_html(ul) {
         // Bring image and annotation scaffolding in
@@ -234,49 +277,11 @@ export class ULabel {
         // const tabs = ULabel.get_toolbox_tabs(ul);
         const images = ULabel.get_images_html(ul);
         const frame_annotation_dialogs = ULabel.get_frame_annotation_dialogs(ul);
-
-        //let configuration = new Configuration();
-
-        console.log(ul)
-
-        // let toolbox_item_order = ul.configuration.default_toolbox_item_order;
-
-        // //create the toolbox
-        // if (toolbox_item_order.length == 0) {
-        //     throw new Error("No Toolbox Items Given")
-        // }
-
-        // let toolbox_instance_list = [];
-        // //Go through the items in toolbox_item_order and add their instance to the toolbox instance list
-        // for (let i = 0; i < toolbox_item_order.length; i++) {
-
-        //     let args, toolbox_key;
-
-        //     //If the value of toolbox_item_order[i] is a number then that means the it is one of the 
-        //     //enumerated toolbox items, so set it to the key, otherwise the element must be an array
-        //     //of which the first element of that array must be the enumerated value, and the arguments
-        //     //must be the second value
-        //     if (typeof(toolbox_item_order[i]) == "number") {
-        //         toolbox_key = toolbox_item_order[i]
-        //     } else {
-
-        //         toolbox_key = toolbox_item_order[i][0];
-        //         args = toolbox_item_order[i][1]  
-        //     }
-
-        //     let toolbox_item_class = ul.Configuration.toolbox_map.get(toolbox_key);
-
-        //     if (args == null) {
-        //         toolbox_instance_list.push(new ul.Configuration.toolbox_item_class(ulabel))
-        //     } else {
-        //         toolbox_instance_list.push(new ul.Configuration.toolbox_item_class(ulabel, args))
-        //     }           
-        // }
         
         // const toolbox = configuration.create_toolbox();
         const toolbox = new Toolbox(
             [],
-            ul.configuration.create_toolbox(ul)
+            ULabel.create_toolbox(ul)
         );
 
 

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -232,8 +232,9 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         var _this = _super.call(this) || this;
         _this.is_vanished = false;
         _this.cached_size = 1.5;
-        _this.keybind_configuration = configuration_1.Configuration.default_keybinds;
         _this.inner_HTML = "<p class=\"tb-header\">Annotation Count</p>";
+        //get default keybinds
+        _this.keybind_configuration = ulabel.config.default_keybinds;
         //event listener for buttons
         $(document).on("click", "a.butt-ann", function (e) {
             var button = $(e.currentTarget);

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -319,11 +319,14 @@ export class AnnotationResizeItem extends ToolboxItem {
     public cached_size: number = 1.5;
     public html: string;
     public inner_HTML: string;
-    private keybind_configuration: {[key: string]: string} = Configuration.default_keybinds
+    private keybind_configuration: {[key: string]: string}
     constructor(ulabel: ULabel) {
         super();
         this.inner_HTML = `<p class="tb-header">Annotation Count</p>`;
         
+        //get default keybinds
+        this.keybind_configuration = ulabel.config.default_keybinds
+
         //event listener for buttons
         $(document).on("click", "a.butt-ann", (e) => {
             let button = $(e.currentTarget);


### PR DESCRIPTION
# Update how the config is handled

## Description

Consolidated ulabel's built-in default config and the configuration class. Now when ulabel is constructed it will add an instance of the config to itself. All of the ulabel config stuff is then added to the configuration class. You can now also pass in new config data to ulabel's construction and it will be added to the configuration class. Also removed the configuration's dependency on ulabel as it was only used for constructing the toolbox, and it really didn't need to be there.

## PR Checklist

- [ ] Merged latest main
- [ ] Version number in `package.json` has been bumped since last release
- [ ] Version numbers match between package `package.json` and `src/version.js`
- [ ] Ran `npm install` and `npm run build` AFTER bumping the version number
- [ ] Updated documentation if necessary (currently just in `api_spec.md`)
- [ ] Added changes to `changelog.md`

## Breaking API Changes

none
