### PR TITLE
Can now use keypoint slider functionality without moving keypoint slider

### DIFF
--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -20064,11 +20064,13 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         _this.filter_function = kwargs.filter_function;
         _this.get_confidence = kwargs.confidence_function;
         _this.mark_deprecated = kwargs.mark_deprecated;
+        _this.slider_bar_id = _this.name.replaceAll(" ", "-").toLowerCase();
         //if the config has a default value override, then use that instead
         if (ulabel.config.hasOwnProperty(_this.name.replaceAll(" ", "_").toLowerCase() + "_default_value")) {
             kwargs._default_value = ulabel.config[_this.name.split(" ").join("_").toLowerCase() + "_default_value"];
         }
-        //if the user doesn't give a default for the slider, then the defalut is 0
+        //if this keypoint slider has a generic default, then use it
+        //otherwise the defalut is 0
         if (kwargs.hasOwnProperty("default_value")) {
             //check to make sure the default value given is valid
             if ((kwargs.default_value >= 0) && (kwargs.default_value <= 1)) {
@@ -20089,17 +20091,15 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         //The annotations are drawn for the first time after the toolbox is loaded
         //so we don't actually have to redraw the annotations after deprecating them.
         $(document).on("input", "#" + _this.name.split(" ").join("-").toLowerCase(), function (e) {
-            var current_subtask_key = ulabel.state["current_subtask"];
-            var current_subtask = ulabel.subtasks[current_subtask_key];
-            //update the slider value text next to the slider
-            $("#" + _this.name.split(" ").join("-").toLowerCase() + "-label").text(e.currentTarget.value + "%");
             var filter_value = e.currentTarget.value / 100;
-            _this.deprecate_annotations(current_subtask, filter_value);
-            ulabel.redraw_all_annotations(null, null, false);
+            _this.deprecate_annotations(ulabel, filter_value);
         });
         return _this;
     }
-    KeypointSliderItem.prototype.deprecate_annotations = function (current_subtask, filter_value) {
+    KeypointSliderItem.prototype.deprecate_annotations = function (ulabel, filter_value) {
+        //get the current subtask
+        var current_subtask_key = ulabel.state["current_subtask"];
+        var current_subtask = ulabel.subtasks[current_subtask_key];
         for (var i in current_subtask.annotations.ordering) {
             var current_annotation = current_subtask.annotations.access[current_subtask.annotations.ordering[i]];
             //kinda a hack, but an annotation can't be human deprecated if its not deprecated
@@ -20114,6 +20114,10 @@ var KeypointSliderItem = /** @class */ (function (_super) {
             var deprecate = this.filter_function(current_confidence, filter_value);
             this.mark_deprecated(current_annotation, deprecate);
         }
+        //Update the slider bar's position, and the label's text.
+        $("#" + this.slider_bar_id).val(Math.round(filter_value * 100));
+        $("#" + this.slider_bar_id + "-label").text(Math.round(filter_value * 100) + "%");
+        ulabel.redraw_all_annotations(null, null, false);
     };
     //if an annotation is deprecated and has a child, then assume its human deprecated.
     KeypointSliderItem.prototype.check_for_human_deprecated = function (current_subtask) {

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -531,11 +531,13 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         _this.filter_function = kwargs.filter_function;
         _this.get_confidence = kwargs.confidence_function;
         _this.mark_deprecated = kwargs.mark_deprecated;
+        _this.slider_bar_id = _this.name.replaceAll(" ", "-").toLowerCase();
         //if the config has a default value override, then use that instead
         if (ulabel.config.hasOwnProperty(_this.name.replaceAll(" ", "_").toLowerCase() + "_default_value")) {
             kwargs._default_value = ulabel.config[_this.name.split(" ").join("_").toLowerCase() + "_default_value"];
         }
-        //if the user doesn't give a default for the slider, then the defalut is 0
+        //if this keypoint slider has a generic default, then use it
+        //otherwise the defalut is 0
         if (kwargs.hasOwnProperty("default_value")) {
             //check to make sure the default value given is valid
             if ((kwargs.default_value >= 0) && (kwargs.default_value <= 1)) {
@@ -556,17 +558,15 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         //The annotations are drawn for the first time after the toolbox is loaded
         //so we don't actually have to redraw the annotations after deprecating them.
         $(document).on("input", "#" + _this.name.split(" ").join("-").toLowerCase(), function (e) {
-            var current_subtask_key = ulabel.state["current_subtask"];
-            var current_subtask = ulabel.subtasks[current_subtask_key];
-            //update the slider value text next to the slider
-            $("#" + _this.name.split(" ").join("-").toLowerCase() + "-label").text(e.currentTarget.value + "%");
             var filter_value = e.currentTarget.value / 100;
-            _this.deprecate_annotations(current_subtask, filter_value);
-            ulabel.redraw_all_annotations(null, null, false);
+            _this.deprecate_annotations(ulabel, filter_value);
         });
         return _this;
     }
-    KeypointSliderItem.prototype.deprecate_annotations = function (current_subtask, filter_value) {
+    KeypointSliderItem.prototype.deprecate_annotations = function (ulabel, filter_value) {
+        //get the current subtask
+        var current_subtask_key = ulabel.state["current_subtask"];
+        var current_subtask = ulabel.subtasks[current_subtask_key];
         for (var i in current_subtask.annotations.ordering) {
             var current_annotation = current_subtask.annotations.access[current_subtask.annotations.ordering[i]];
             //kinda a hack, but an annotation can't be human deprecated if its not deprecated
@@ -581,6 +581,10 @@ var KeypointSliderItem = /** @class */ (function (_super) {
             var deprecate = this.filter_function(current_confidence, filter_value);
             this.mark_deprecated(current_annotation, deprecate);
         }
+        //Update the slider bar's position, and the label's text.
+        $("#" + this.slider_bar_id).val(Math.round(filter_value * 100));
+        $("#" + this.slider_bar_id + "-label").text(Math.round(filter_value * 100) + "%");
+        ulabel.redraw_all_annotations(null, null, false);
     };
     //if an annotation is deprecated and has a child, then assume its human deprecated.
     KeypointSliderItem.prototype.check_for_human_deprecated = function (current_subtask) {


### PR DESCRIPTION
# Can now use keypoint slider functionality without moving keypoint slider

## Description

deprecate_annotations now updates both the keypoint slider value to whatever value was passed into it, as well as the keypoint slider label. This allows us to call the deprecate_annotations method from anywhere and the slider will be updated accordingly.

## PR Checklist

- [ ] Merged latest main
- [ ] Version number in `package.json` has been bumped since last release
- [ ] Version numbers match between package `package.json` and `src/version.js`
- [ ] Ran `npm install` and `npm run build` AFTER bumping the version number
- [ ] Updated documentation if necessary (currently just in `api_spec.md`)
- [ ] Added changes to `changelog.md`

## Breaking API Changes

none
