### PR TITLE
On load check for annotation size cookie or config default

### DIFF
--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -19868,6 +19868,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
             for (var annotation_id in subtask.annotations.access) {
                 subtask.annotations.access[annotation_id].line_size = size;
             }
+            this.set_size_cookie(size);
             return;
         }
         if (operation == "+") {
@@ -19876,6 +19877,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
                 //temporary solution
                 this.cached_size = subtask.annotations.access[annotation_id].line_size;
             }
+            this.set_size_cookie(subtask.annotations.access[subtask.annotations.ordering[0]].line_size);
             return;
         }
         if (operation == "-") {
@@ -19891,9 +19893,31 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
                 //temporary solution
                 this.cached_size = subtask.annotations.access[annotation_id].line_size;
             }
+            this.set_size_cookie(subtask.annotations.access[subtask.annotations.ordering[0]].line_size);
             return;
         }
-        return;
+        throw Error("Invalid Operation given to loop_through_annotations");
+    };
+    AnnotationResizeItem.prototype.set_size_cookie = function (cookie_value) {
+        var d = new Date();
+        d.setTime(d.getTime() + (10000 * 24 * 60 * 60 * 1000));
+        document.cookie = "size=" + cookie_value + ";" + d.toUTCString() + ";path=/";
+        console.log(document.cookie);
+    };
+    AnnotationResizeItem.prototype.read_size_cookie = function () {
+        var cookie_name = "size=";
+        var cookie_array = document.cookie.split(";");
+        for (var i = 0; i < cookie_array.length; i++) {
+            var current_cookie = cookie_array[i];
+            //while there's whitespace at the front of the cookie, loop through and remove it
+            while (current_cookie.charAt(0) == " ") {
+                current_cookie = current_cookie.substring(1);
+            }
+            if (current_cookie.indexOf(cookie_name) == 0) {
+                return current_cookie.substring(cookie_name.length, current_cookie.length);
+            }
+        }
+        return null;
     };
     AnnotationResizeItem.prototype.get_html = function () {
         return "\n        <div class=\"annotation-resize\">\n            <p class=\"tb-header\">Change Annotation Size</p>\n            <div class=\"annotation-resize-button-holder\">\n                <span class=\"annotation-vanish\">\n                    <a href=\"#\" class=\"butt-ann\" id=\"annotation-resize-v\">Vanish</a>\n                </span>\n                <span class=\"annotation-size\">\n                    <a href=\"#\" class=\"butt-ann\" id=\"annotation-resize-s\">Small</a>\n                    <a href=\"#\" class=\"butt-ann\" id=\"annotation-resize-l\">Large</a>\n                </span>\n                <span class=\"annotation-inc\">\n                    <a href=\"#\" class=\"butt-ann\" id=\"annotation-resize-inc\">+</a>\n                    <a href=\"#\" class=\"butt-ann\" id=\"annotation-resize-dec\">-</a>\n                </span>\n            </div>\n        </div>\n        ";

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -19769,18 +19769,17 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         _this.inner_HTML = "<p class=\"tb-header\">Annotation Count</p>";
         //get default keybinds
         _this.keybind_configuration = ulabel.config.default_keybinds;
+        //grab current subtask for convinience
+        var current_subtask_key = ulabel.state["current_subtask"];
+        var current_subtask = ulabel.subtasks[current_subtask_key];
         //First check for a size cookie, if one isn't found then check the config
         //for a default annotation size. If neither are found it will use the size
         //that the annotation was saved as.
-        console.log(_this.read_size_cookie());
-        if (_this.read_size_cookie() != null) {
-            var current_subtask_key = ulabel.state["current_subtask"];
-            var current_subtask = ulabel.subtasks[current_subtask_key];
-            _this.update_annotation_size(current_subtask, Number(_this.read_size_cookie()));
+        console.log(_this.read_size_cookie(current_subtask));
+        if (_this.read_size_cookie(current_subtask) != null) {
+            _this.update_annotation_size(current_subtask, Number(_this.read_size_cookie(current_subtask)));
         }
         else if (ulabel.config.default_annotation_size != undefined) {
-            var current_subtask_key = ulabel.state["current_subtask"];
-            var current_subtask = ulabel.subtasks[current_subtask_key];
             _this.update_annotation_size(current_subtask, ulabel.config.default_annotation_size);
         }
         //event listener for buttons
@@ -19876,7 +19875,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
             for (var annotation_id in subtask.annotations.access) {
                 subtask.annotations.access[annotation_id].line_size = size;
             }
-            this.set_size_cookie(size);
+            this.set_size_cookie(size, subtask);
             return;
         }
         if (operation == "+") {
@@ -19885,7 +19884,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
                 //temporary solution
                 this.cached_size = subtask.annotations.access[annotation_id].line_size;
             }
-            this.set_size_cookie(subtask.annotations.access[subtask.annotations.ordering[0]].line_size);
+            this.set_size_cookie(subtask.annotations.access[subtask.annotations.ordering[0]].line_size, subtask);
             return;
         }
         if (operation == "-") {
@@ -19901,20 +19900,20 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
                 //temporary solution
                 this.cached_size = subtask.annotations.access[annotation_id].line_size;
             }
-            this.set_size_cookie(subtask.annotations.access[subtask.annotations.ordering[0]].line_size);
+            this.set_size_cookie(subtask.annotations.access[subtask.annotations.ordering[0]].line_size, subtask);
             return;
         }
         throw Error("Invalid Operation given to loop_through_annotations");
     };
-    AnnotationResizeItem.prototype.set_size_cookie = function (cookie_value) {
+    AnnotationResizeItem.prototype.set_size_cookie = function (cookie_value, subtask) {
         var d = new Date();
         d.setTime(d.getTime() + (10000 * 24 * 60 * 60 * 1000));
-        document.cookie = "size=" + cookie_value + ";" + d.toUTCString() + ";path=/";
-        console.log(document.cookie);
+        var subtask_name = subtask.display_name.replaceAll(" ", "_").toLowerCase();
+        document.cookie = subtask_name + "_size=" + cookie_value + ";" + d.toUTCString() + ";path=/";
     };
-    AnnotationResizeItem.prototype.read_size_cookie = function () {
-        console.log("read size cookie", document.cookie);
-        var cookie_name = "size=";
+    AnnotationResizeItem.prototype.read_size_cookie = function (subtask) {
+        var subtask_name = subtask.display_name.replaceAll(" ", "_").toLowerCase();
+        var cookie_name = subtask_name + "_size=";
         var cookie_array = document.cookie.split(";");
         for (var i = 0; i < cookie_array.length; i++) {
             var current_cookie = cookie_array[i];

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -19769,8 +19769,16 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         _this.inner_HTML = "<p class=\"tb-header\">Annotation Count</p>";
         //get default keybinds
         _this.keybind_configuration = ulabel.config.default_keybinds;
-        //check for default annotation size and update annotations
-        if (ulabel.config.default_annotation_size != undefined) {
+        //First check for a size cookie, if one isn't found then check the config
+        //for a default annotation size. If neither are found it will use the size
+        //that the annotation was saved as.
+        console.log(_this.read_size_cookie());
+        if (_this.read_size_cookie() != null) {
+            var current_subtask_key = ulabel.state["current_subtask"];
+            var current_subtask = ulabel.subtasks[current_subtask_key];
+            _this.update_annotation_size(current_subtask, Number(_this.read_size_cookie()));
+        }
+        else if (ulabel.config.default_annotation_size != undefined) {
             var current_subtask_key = ulabel.state["current_subtask"];
             var current_subtask = ulabel.subtasks[current_subtask_key];
             _this.update_annotation_size(current_subtask, ulabel.config.default_annotation_size);
@@ -19905,6 +19913,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         console.log(document.cookie);
     };
     AnnotationResizeItem.prototype.read_size_cookie = function () {
+        console.log("read size cookie", document.cookie);
         var cookie_name = "size=";
         var cookie_array = document.cookie.split(";");
         for (var i = 0; i < cookie_array.length; i++) {

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -11721,6 +11721,7 @@ var Configuration = /** @class */ (function () {
             "annotation_size_minus": "-",
             "annotation_vanish": "v" //The v Key by default
         };
+        this.default_annotation_size = 6;
         this.filter_annotations_on_load = false;
         this.modify_config.apply(this, kwargs);
     }
@@ -19768,6 +19769,12 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         _this.inner_HTML = "<p class=\"tb-header\">Annotation Count</p>";
         //get default keybinds
         _this.keybind_configuration = ulabel.config.default_keybinds;
+        //check for default annotation size and update annotations
+        if (ulabel.config.default_annotation_size != undefined) {
+            var current_subtask_key = ulabel.state["current_subtask"];
+            var current_subtask = ulabel.subtasks[current_subtask_key];
+            _this.update_annotation_size(current_subtask, ulabel.config.default_annotation_size);
+        }
         //event listener for buttons
         $(document).on("click", "a.butt-ann", function (e) {
             var button = $(e.currentTarget);
@@ -19804,6 +19811,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         return _this;
     }
     //recieives a string of 's', 'l', 'dec', 'inc', or 'v' depending on which button was pressed
+    //also the constructor can pass in a number from the config
     AnnotationResizeItem.prototype.update_annotation_size = function (subtask, size) {
         var small_size = 1.5;
         var large_size = 5;
@@ -19815,6 +19823,9 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         //pressed, then we want to ignore the input
         if (this.is_vanished && size !== "v")
             return;
+        if (typeof (size) === "number") {
+            this.loop_through_annotations(subtask, size, "=");
+        }
         if (size == "v") {
             if (this.is_vanished) {
                 this.loop_through_annotations(subtask, this.cached_size, "=");

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -51,6 +51,7 @@ var Configuration = /** @class */ (function () {
             "annotation_size_minus": "-",
             "annotation_vanish": "v" //The v Key by default
         };
+        this.default_annotation_size = 6;
         this.filter_annotations_on_load = false;
         this.modify_config.apply(this, kwargs);
     }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -47,6 +47,8 @@ export class Configuration {
         "annotation_vanish": "v"      //The v Key by default
     }
 
+    public default_annotation_size: number = 6;
+
     public filter_low_confidence_default_value: number;
 
     public filter_annotations_on_load: boolean = false;

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -235,6 +235,12 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         _this.inner_HTML = "<p class=\"tb-header\">Annotation Count</p>";
         //get default keybinds
         _this.keybind_configuration = ulabel.config.default_keybinds;
+        //check for default annotation size and update annotations
+        if (ulabel.config.default_annotation_size != undefined) {
+            var current_subtask_key = ulabel.state["current_subtask"];
+            var current_subtask = ulabel.subtasks[current_subtask_key];
+            _this.update_annotation_size(current_subtask, ulabel.config.default_annotation_size);
+        }
         //event listener for buttons
         $(document).on("click", "a.butt-ann", function (e) {
             var button = $(e.currentTarget);
@@ -271,6 +277,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         return _this;
     }
     //recieives a string of 's', 'l', 'dec', 'inc', or 'v' depending on which button was pressed
+    //also the constructor can pass in a number from the config
     AnnotationResizeItem.prototype.update_annotation_size = function (subtask, size) {
         var small_size = 1.5;
         var large_size = 5;
@@ -282,6 +289,9 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         //pressed, then we want to ignore the input
         if (this.is_vanished && size !== "v")
             return;
+        if (typeof (size) === "number") {
+            this.loop_through_annotations(subtask, size, "=");
+        }
         if (size == "v") {
             if (this.is_vanished) {
                 this.loop_through_annotations(subtask, this.cached_size, "=");

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -235,8 +235,16 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         _this.inner_HTML = "<p class=\"tb-header\">Annotation Count</p>";
         //get default keybinds
         _this.keybind_configuration = ulabel.config.default_keybinds;
-        //check for default annotation size and update annotations
-        if (ulabel.config.default_annotation_size != undefined) {
+        //First check for a size cookie, if one isn't found then check the config
+        //for a default annotation size. If neither are found it will use the size
+        //that the annotation was saved as.
+        console.log(_this.read_size_cookie());
+        if (_this.read_size_cookie() != null) {
+            var current_subtask_key = ulabel.state["current_subtask"];
+            var current_subtask = ulabel.subtasks[current_subtask_key];
+            _this.update_annotation_size(current_subtask, Number(_this.read_size_cookie()));
+        }
+        else if (ulabel.config.default_annotation_size != undefined) {
             var current_subtask_key = ulabel.state["current_subtask"];
             var current_subtask = ulabel.subtasks[current_subtask_key];
             _this.update_annotation_size(current_subtask, ulabel.config.default_annotation_size);
@@ -371,6 +379,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         console.log(document.cookie);
     };
     AnnotationResizeItem.prototype.read_size_cookie = function () {
+        console.log("read size cookie", document.cookie);
         var cookie_name = "size=";
         var cookie_array = document.cookie.split(";");
         for (var i = 0; i < cookie_array.length; i++) {

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -235,18 +235,17 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         _this.inner_HTML = "<p class=\"tb-header\">Annotation Count</p>";
         //get default keybinds
         _this.keybind_configuration = ulabel.config.default_keybinds;
+        //grab current subtask for convinience
+        var current_subtask_key = ulabel.state["current_subtask"];
+        var current_subtask = ulabel.subtasks[current_subtask_key];
         //First check for a size cookie, if one isn't found then check the config
         //for a default annotation size. If neither are found it will use the size
         //that the annotation was saved as.
-        console.log(_this.read_size_cookie());
-        if (_this.read_size_cookie() != null) {
-            var current_subtask_key = ulabel.state["current_subtask"];
-            var current_subtask = ulabel.subtasks[current_subtask_key];
-            _this.update_annotation_size(current_subtask, Number(_this.read_size_cookie()));
+        console.log(_this.read_size_cookie(current_subtask));
+        if (_this.read_size_cookie(current_subtask) != null) {
+            _this.update_annotation_size(current_subtask, Number(_this.read_size_cookie(current_subtask)));
         }
         else if (ulabel.config.default_annotation_size != undefined) {
-            var current_subtask_key = ulabel.state["current_subtask"];
-            var current_subtask = ulabel.subtasks[current_subtask_key];
             _this.update_annotation_size(current_subtask, ulabel.config.default_annotation_size);
         }
         //event listener for buttons
@@ -342,7 +341,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
             for (var annotation_id in subtask.annotations.access) {
                 subtask.annotations.access[annotation_id].line_size = size;
             }
-            this.set_size_cookie(size);
+            this.set_size_cookie(size, subtask);
             return;
         }
         if (operation == "+") {
@@ -351,7 +350,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
                 //temporary solution
                 this.cached_size = subtask.annotations.access[annotation_id].line_size;
             }
-            this.set_size_cookie(subtask.annotations.access[subtask.annotations.ordering[0]].line_size);
+            this.set_size_cookie(subtask.annotations.access[subtask.annotations.ordering[0]].line_size, subtask);
             return;
         }
         if (operation == "-") {
@@ -367,20 +366,20 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
                 //temporary solution
                 this.cached_size = subtask.annotations.access[annotation_id].line_size;
             }
-            this.set_size_cookie(subtask.annotations.access[subtask.annotations.ordering[0]].line_size);
+            this.set_size_cookie(subtask.annotations.access[subtask.annotations.ordering[0]].line_size, subtask);
             return;
         }
         throw Error("Invalid Operation given to loop_through_annotations");
     };
-    AnnotationResizeItem.prototype.set_size_cookie = function (cookie_value) {
+    AnnotationResizeItem.prototype.set_size_cookie = function (cookie_value, subtask) {
         var d = new Date();
         d.setTime(d.getTime() + (10000 * 24 * 60 * 60 * 1000));
-        document.cookie = "size=" + cookie_value + ";" + d.toUTCString() + ";path=/";
-        console.log(document.cookie);
+        var subtask_name = subtask.display_name.replaceAll(" ", "_").toLowerCase();
+        document.cookie = subtask_name + "_size=" + cookie_value + ";" + d.toUTCString() + ";path=/";
     };
-    AnnotationResizeItem.prototype.read_size_cookie = function () {
-        console.log("read size cookie", document.cookie);
-        var cookie_name = "size=";
+    AnnotationResizeItem.prototype.read_size_cookie = function (subtask) {
+        var subtask_name = subtask.display_name.replaceAll(" ", "_").toLowerCase();
+        var cookie_name = subtask_name + "_size=";
         var cookie_array = document.cookie.split(";");
         for (var i = 0; i < cookie_array.length; i++) {
             var current_cookie = cookie_array[i];

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -334,6 +334,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
             for (var annotation_id in subtask.annotations.access) {
                 subtask.annotations.access[annotation_id].line_size = size;
             }
+            this.set_size_cookie(size);
             return;
         }
         if (operation == "+") {
@@ -342,6 +343,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
                 //temporary solution
                 this.cached_size = subtask.annotations.access[annotation_id].line_size;
             }
+            this.set_size_cookie(subtask.annotations.access[subtask.annotations.ordering[0]].line_size);
             return;
         }
         if (operation == "-") {
@@ -357,9 +359,31 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
                 //temporary solution
                 this.cached_size = subtask.annotations.access[annotation_id].line_size;
             }
+            this.set_size_cookie(subtask.annotations.access[subtask.annotations.ordering[0]].line_size);
             return;
         }
-        return;
+        throw Error("Invalid Operation given to loop_through_annotations");
+    };
+    AnnotationResizeItem.prototype.set_size_cookie = function (cookie_value) {
+        var d = new Date();
+        d.setTime(d.getTime() + (10000 * 24 * 60 * 60 * 1000));
+        document.cookie = "size=" + cookie_value + ";" + d.toUTCString() + ";path=/";
+        console.log(document.cookie);
+    };
+    AnnotationResizeItem.prototype.read_size_cookie = function () {
+        var cookie_name = "size=";
+        var cookie_array = document.cookie.split(";");
+        for (var i = 0; i < cookie_array.length; i++) {
+            var current_cookie = cookie_array[i];
+            //while there's whitespace at the front of the cookie, loop through and remove it
+            while (current_cookie.charAt(0) == " ") {
+                current_cookie = current_cookie.substring(1);
+            }
+            if (current_cookie.indexOf(cookie_name) == 0) {
+                return current_cookie.substring(cookie_name.length, current_cookie.length);
+            }
+        }
+        return null;
     };
     AnnotationResizeItem.prototype.get_html = function () {
         return "\n        <div class=\"annotation-resize\">\n            <p class=\"tb-header\">Change Annotation Size</p>\n            <div class=\"annotation-resize-button-holder\">\n                <span class=\"annotation-vanish\">\n                    <a href=\"#\" class=\"butt-ann\" id=\"annotation-resize-v\">Vanish</a>\n                </span>\n                <span class=\"annotation-size\">\n                    <a href=\"#\" class=\"butt-ann\" id=\"annotation-resize-s\">Small</a>\n                    <a href=\"#\" class=\"butt-ann\" id=\"annotation-resize-l\">Large</a>\n                </span>\n                <span class=\"annotation-inc\">\n                    <a href=\"#\" class=\"butt-ann\" id=\"annotation-resize-inc\">+</a>\n                    <a href=\"#\" class=\"butt-ann\" id=\"annotation-resize-dec\">-</a>\n                </span>\n            </div>\n        </div>\n        ";

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -431,6 +431,7 @@ export class AnnotationResizeItem extends ToolboxItem {
             for (const annotation_id in subtask.annotations.access) {
                 subtask.annotations.access[annotation_id].line_size = size;
             }
+            this.set_size_cookie(size)
             return;
         }
         if (operation == "+") {
@@ -439,6 +440,7 @@ export class AnnotationResizeItem extends ToolboxItem {
                 //temporary solution
                 this.cached_size = subtask.annotations.access[annotation_id].line_size
             }
+            this.set_size_cookie(subtask.annotations.access[subtask.annotations.ordering[0]].line_size)
             return;
         }
         if (operation == "-") {
@@ -453,9 +455,38 @@ export class AnnotationResizeItem extends ToolboxItem {
                 //temporary solution
                 this.cached_size = subtask.annotations.access[annotation_id].line_size
             }
+            this.set_size_cookie(subtask.annotations.access[subtask.annotations.ordering[0]].line_size)
             return;
         }
-        return;
+        throw Error("Invalid Operation given to loop_through_annotations")
+    }
+
+    private set_size_cookie(cookie_value) {
+        let d = new Date();
+        d.setTime(d.getTime() + (10000 * 24 * 60 * 60 * 1000));
+        document.cookie = "size=" + cookie_value + ";" + d.toUTCString() + ";path=/";
+        console.log(document.cookie)
+    }
+
+    private read_size_cookie() {
+        let cookie_name = "size=";       
+
+        let cookie_array = document.cookie.split(";");
+
+        for (let i = 0; i < cookie_array.length; i++) {
+            let current_cookie = cookie_array[i];
+
+            //while there's whitespace at the front of the cookie, loop through and remove it
+            while (current_cookie.charAt(0) == " ") {
+                current_cookie = current_cookie.substring(1);
+            }
+
+            if (current_cookie.indexOf(cookie_name) == 0) {
+                return current_cookie.substring(cookie_name.length, current_cookie.length)
+            }
+        }
+
+        return null
     }
     
     public get_html() {

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -327,8 +327,16 @@ export class AnnotationResizeItem extends ToolboxItem {
         //get default keybinds
         this.keybind_configuration = ulabel.config.default_keybinds
 
-        //check for default annotation size and update annotations
-        if (ulabel.config.default_annotation_size != undefined) {
+        //First check for a size cookie, if one isn't found then check the config
+        //for a default annotation size. If neither are found it will use the size
+        //that the annotation was saved as.
+        console.log(this.read_size_cookie())
+        if (this.read_size_cookie() != null) {
+            let current_subtask_key = ulabel.state["current_subtask"];
+            let current_subtask = ulabel.subtasks[current_subtask_key];
+            this.update_annotation_size(current_subtask, Number(this.read_size_cookie()));
+        } 
+        else if (ulabel.config.default_annotation_size != undefined) {
             let current_subtask_key = ulabel.state["current_subtask"];
             let current_subtask = ulabel.subtasks[current_subtask_key];
             this.update_annotation_size(current_subtask, ulabel.config.default_annotation_size);
@@ -367,7 +375,7 @@ export class AnnotationResizeItem extends ToolboxItem {
             }
             ulabel.redraw_all_annotations(null, null, false);
         } )
-        }
+    }
         
 
     //recieives a string of 's', 'l', 'dec', 'inc', or 'v' depending on which button was pressed
@@ -469,6 +477,7 @@ export class AnnotationResizeItem extends ToolboxItem {
     }
 
     private read_size_cookie() {
+        console.log("read size cookie", document.cookie)
         let cookie_name = "size=";       
 
         let cookie_array = document.cookie.split(";");

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -327,18 +327,18 @@ export class AnnotationResizeItem extends ToolboxItem {
         //get default keybinds
         this.keybind_configuration = ulabel.config.default_keybinds
 
+        //grab current subtask for convinience
+        let current_subtask_key = ulabel.state["current_subtask"];
+        let current_subtask = ulabel.subtasks[current_subtask_key];
+
         //First check for a size cookie, if one isn't found then check the config
         //for a default annotation size. If neither are found it will use the size
         //that the annotation was saved as.
-        console.log(this.read_size_cookie())
-        if (this.read_size_cookie() != null) {
-            let current_subtask_key = ulabel.state["current_subtask"];
-            let current_subtask = ulabel.subtasks[current_subtask_key];
-            this.update_annotation_size(current_subtask, Number(this.read_size_cookie()));
+        console.log(this.read_size_cookie(current_subtask))
+        if (this.read_size_cookie(current_subtask) != null) {           
+            this.update_annotation_size(current_subtask, Number(this.read_size_cookie(current_subtask)));
         } 
-        else if (ulabel.config.default_annotation_size != undefined) {
-            let current_subtask_key = ulabel.state["current_subtask"];
-            let current_subtask = ulabel.subtasks[current_subtask_key];
+        else if (ulabel.config.default_annotation_size != undefined) {          
             this.update_annotation_size(current_subtask, ulabel.config.default_annotation_size);
         }
 
@@ -439,7 +439,7 @@ export class AnnotationResizeItem extends ToolboxItem {
             for (const annotation_id in subtask.annotations.access) {
                 subtask.annotations.access[annotation_id].line_size = size;
             }
-            this.set_size_cookie(size)
+            this.set_size_cookie(size, subtask)
             return;
         }
         if (operation == "+") {
@@ -448,7 +448,7 @@ export class AnnotationResizeItem extends ToolboxItem {
                 //temporary solution
                 this.cached_size = subtask.annotations.access[annotation_id].line_size
             }
-            this.set_size_cookie(subtask.annotations.access[subtask.annotations.ordering[0]].line_size)
+            this.set_size_cookie(subtask.annotations.access[subtask.annotations.ordering[0]].line_size, subtask)
             return;
         }
         if (operation == "-") {
@@ -463,22 +463,26 @@ export class AnnotationResizeItem extends ToolboxItem {
                 //temporary solution
                 this.cached_size = subtask.annotations.access[annotation_id].line_size
             }
-            this.set_size_cookie(subtask.annotations.access[subtask.annotations.ordering[0]].line_size)
+            this.set_size_cookie(subtask.annotations.access[subtask.annotations.ordering[0]].line_size, subtask)
             return;
         }
         throw Error("Invalid Operation given to loop_through_annotations")
     }
 
-    private set_size_cookie(cookie_value) {
+    private set_size_cookie(cookie_value, subtask) {
         let d = new Date();
         d.setTime(d.getTime() + (10000 * 24 * 60 * 60 * 1000));
-        document.cookie = "size=" + cookie_value + ";" + d.toUTCString() + ";path=/";
-        console.log(document.cookie)
+
+        let subtask_name = subtask.display_name.replaceAll(" ","_").toLowerCase();
+
+        document.cookie = subtask_name + "_size=" + cookie_value + ";" + d.toUTCString() + ";path=/";
     }
 
-    private read_size_cookie() {
-        console.log("read size cookie", document.cookie)
-        let cookie_name = "size=";       
+    private read_size_cookie(subtask) {
+
+        let subtask_name = subtask.display_name.replaceAll(" ","_").toLowerCase();
+
+        let cookie_name = subtask_name + "_size=";       
 
         let cookie_array = document.cookie.split(";");
 

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -327,6 +327,13 @@ export class AnnotationResizeItem extends ToolboxItem {
         //get default keybinds
         this.keybind_configuration = ulabel.config.default_keybinds
 
+        //check for default annotation size and update annotations
+        if (ulabel.config.default_annotation_size != undefined) {
+            let current_subtask_key = ulabel.state["current_subtask"];
+            let current_subtask = ulabel.subtasks[current_subtask_key];
+            this.update_annotation_size(current_subtask, ulabel.config.default_annotation_size);
+        }
+
         //event listener for buttons
         $(document).on("click", "a.butt-ann", (e) => {
             let button = $(e.currentTarget);
@@ -364,6 +371,7 @@ export class AnnotationResizeItem extends ToolboxItem {
         
 
     //recieives a string of 's', 'l', 'dec', 'inc', or 'v' depending on which button was pressed
+    //also the constructor can pass in a number from the config
     public update_annotation_size(subtask, size) {
         const small_size = 1.5;
         const large_size = 5;
@@ -374,7 +382,11 @@ export class AnnotationResizeItem extends ToolboxItem {
 
         //If the annotations are currently vanished and a button other than the vanish button is
         //pressed, then we want to ignore the input
-        if(this.is_vanished && size !== "v") return;
+        if (this.is_vanished && size !== "v") return;
+
+        if (typeof(size) === "number") {
+            this.loop_through_annotations(subtask, size, "=");
+        }
 
         if (size == "v") {
             if (this.is_vanished) { 


### PR DESCRIPTION
# On load check for annotation size cookie or config default

## Description

Added that ability to change the default annotation size in the config. Additionally saves a cookie with the size of the annotations per subtask. On load, uses the cookie size for the annotations if it exists. If cookie doesn't exist, then uses the config's default. If neither exist, then if uses the size saved to the annotation like before this pull request.

## PR Checklist

- [ ] Merged latest main
- [ ] Version number in `package.json` has been bumped since last release
- [ ] Version numbers match between package `package.json` and `src/version.js`
- [ ] Ran `npm install` and `npm run build` AFTER bumping the version number
- [ ] Updated documentation if necessary (currently just in `api_spec.md`)
- [ ] Added changes to `changelog.md`

## Breaking API Changes

none
