### PR TITLE
better edit candidates

### DIFF
--- a/demo/multi-class.html
+++ b/demo/multi-class.html
@@ -49,7 +49,7 @@
                                 "id": 12
                             },
                         ],
-                        "allowed_modes": ["bbox", "polygon", "contour"],
+                        "allowed_modes": ["bbox", "polygon", "contour", "polyline"],
                         "resume_from": null,
                         "task_meta": null,
                         "annotation_meta": null

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -17233,7 +17233,6 @@ class ULabel {
             "annid": null,
             "access": null,
             "distance": max_dist / this.get_empirical_scale(),
-            // "distance": Infinity,
             "point": null
         };
         if (candidates == null) {
@@ -17330,8 +17329,7 @@ class ULabel {
         var ret = {
             "annid": null,
             "access": null,
-            "distance": Infinity,
-            // "distance": Infinity,
+            "distance": max_dist / this.get_empirical_scale(),
             "point": null
         };
         if (candidates == null) {
@@ -17350,7 +17348,7 @@ class ULabel {
                     var npi = geometric_utils/* GeometricUtils.get_nearest_point_on_polygon */.Z.get_nearest_point_on_polygon(
                         global_x, global_y,
                         this.subtasks[this.state["current_subtask"]]["annotations"]["access"][edid]["spatial_payload"],
-                        Infinity, true
+                        max_dist / this.get_empirical_scale(), true
                     );
                     if (npi["distance"] != null && npi["distance"] < ret["distance"]) {
                         ret["annid"] = edid;
@@ -18688,7 +18686,6 @@ class ULabel {
                 }
             }
         }
-        console.log(ret["candidate_ids"].length);
         return ret;
     }
 
@@ -18724,17 +18721,15 @@ class ULabel {
 
             // Look for an existing point that's close enough to suggest editing it
             const nearest_active_keypoint = this.get_nearest_active_keypoint(global_x, global_y, dst_thresh, edit_candidates["candidate_ids"]);
-            console.log(nearest_active_keypoint)
             if (nearest_active_keypoint != null && nearest_active_keypoint.point != null) {
                 this.subtasks[this.state["current_subtask"]]["state"]["edit_candidate"] = nearest_active_keypoint;
                 this.show_edit_suggestion(nearest_active_keypoint, true);
                 edit_candidates["best"] = nearest_active_keypoint;
             }
             else { // If none are found, look for a point along a segment that's close enough
-                const nearest_segment_point = this.get_nearest_segment_point(global_x, global_y, dst_thresh, edit_candidates["candidate_ids"]);
+                const nearest_segment_point = this.get_nearest_segment_point(global_x, global_y, Infinity, edit_candidates["candidate_ids"]);
                 if (nearest_segment_point != null && nearest_segment_point.point != null) {
                     this.subtasks[this.state["current_subtask"]]["state"]["edit_candidate"] = nearest_segment_point;
-                    // var display_soft = nearest_segment_point['distance'] > dst_thresh;
                     this.show_edit_suggestion(nearest_segment_point, false);
                     edit_candidates["best"] = nearest_segment_point;
                 }

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -18700,7 +18700,6 @@ class ULabel {
             }
 
             const dst_thresh = this.config["edit_handle_size"] / 2;
-            // const dst_thresh = this.config["image_width"];
             const global_x = this.get_global_mouse_x(mouse_event);
             const global_y = this.get_global_mouse_y(mouse_event);
 

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -17233,6 +17233,7 @@ class ULabel {
             "annid": null,
             "access": null,
             "distance": max_dist / this.get_empirical_scale(),
+            // "distance": Infinity,
             "point": null
         };
         if (candidates == null) {
@@ -17281,7 +17282,7 @@ class ULabel {
                     npi = geometric_utils/* GeometricUtils.get_nearest_point_on_polygon */.Z.get_nearest_point_on_polygon(
                         global_x, global_y,
                         this.subtasks[this.state["current_subtask"]]["annotations"]["access"][edid]["spatial_payload"],
-                        max_dist, false
+                        ret['distance'], true
                     );
                     if (npi["distance"] < ret["distance"]) {
                         ret["annid"] = edid;
@@ -17317,11 +17318,20 @@ class ULabel {
         return ret;
     }
 
+    /**
+     * Get the distance to various types of annotations
+     * @param {*} global_x 
+     * @param {*} global_y 
+     * @param {*} max_dist 
+     * @param {*} candidates 
+     * @returns 
+     */
     get_nearest_segment_point(global_x, global_y, max_dist, candidates = null) {
         var ret = {
             "annid": null,
             "access": null,
             "distance": max_dist / this.get_empirical_scale(),
+            // "distance": Infinity,
             "point": null
         };
         if (candidates == null) {
@@ -17340,7 +17350,7 @@ class ULabel {
                     var npi = geometric_utils/* GeometricUtils.get_nearest_point_on_polygon */.Z.get_nearest_point_on_polygon(
                         global_x, global_y,
                         this.subtasks[this.state["current_subtask"]]["annotations"]["access"][edid]["spatial_payload"],
-                        max_dist / this.get_empirical_scale(), true
+                        ret['distance'], false
                     );
                     if (npi["distance"] != null && npi["distance"] < ret["distance"]) {
                         ret["annid"] = edid;
@@ -18623,6 +18633,13 @@ class ULabel {
         this.update_frame(diffZ);
     }
 
+    /**
+     * Get best candidates for the edit dialog 
+     * @param {*} gblx 
+     * @param {*} gbly 
+     * @param {*} dst_thresh 
+     * @returns 
+     */
     get_edit_candidates(gblx, gbly, dst_thresh) {
         dst_thresh /= this.get_empirical_scale();
         let ret = {
@@ -18671,9 +18688,13 @@ class ULabel {
                 }
             }
         }
+        console.log(ret["candidate_ids"].length);
         return ret;
     }
 
+    /** 
+     * Find the best candidate for opening the global edit
+     */  
     suggest_edits(mouse_event = null, nonspatial_id = null) {
         let best_candidate;
         if (nonspatial_id == null) {
@@ -18682,6 +18703,7 @@ class ULabel {
             }
 
             const dst_thresh = this.config["edit_handle_size"] / 2;
+            // const dst_thresh = this.config["image_width"];
             const global_x = this.get_global_mouse_x(mouse_event);
             const global_y = this.get_global_mouse_y(mouse_event);
 
@@ -18702,6 +18724,7 @@ class ULabel {
 
             // Look for an existing point that's close enough to suggest editing it
             const nearest_active_keypoint = this.get_nearest_active_keypoint(global_x, global_y, dst_thresh, edit_candidates["candidate_ids"]);
+            console.log(nearest_active_keypoint)
             if (nearest_active_keypoint != null && nearest_active_keypoint.point != null) {
                 this.subtasks[this.state["current_subtask"]]["state"]["edit_candidate"] = nearest_active_keypoint;
                 this.show_edit_suggestion(nearest_active_keypoint, true);

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -17330,7 +17330,7 @@ class ULabel {
         var ret = {
             "annid": null,
             "access": null,
-            "distance": max_dist / this.get_empirical_scale(),
+            "distance": Infinity,
             // "distance": Infinity,
             "point": null
         };
@@ -17350,7 +17350,7 @@ class ULabel {
                     var npi = geometric_utils/* GeometricUtils.get_nearest_point_on_polygon */.Z.get_nearest_point_on_polygon(
                         global_x, global_y,
                         this.subtasks[this.state["current_subtask"]]["annotations"]["access"][edid]["spatial_payload"],
-                        max_dist / this.get_empirical_scale(), false
+                        Infinity, true
                     );
                     if (npi["distance"] != null && npi["distance"] < ret["distance"]) {
                         ret["annid"] = edid;
@@ -18734,6 +18734,7 @@ class ULabel {
                 const nearest_segment_point = this.get_nearest_segment_point(global_x, global_y, dst_thresh, edit_candidates["candidate_ids"]);
                 if (nearest_segment_point != null && nearest_segment_point.point != null) {
                     this.subtasks[this.state["current_subtask"]]["state"]["edit_candidate"] = nearest_segment_point;
+                    // var display_soft = nearest_segment_point['distance'] > dst_thresh;
                     this.show_edit_suggestion(nearest_segment_point, false);
                     edit_candidates["best"] = nearest_segment_point;
                 }

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -17228,6 +17228,14 @@ class ULabel {
     }
 
 
+    /**
+     * Get the annotation with nearest active keypoint (e.g. corners for a bbox, endpoints for polylines) to a point
+     * @param {*} global_x 
+     * @param {*} global_y 
+     * @param {*} max_dist Maximum distance to search
+     * @param {*} candidates Candidates to search across
+     * @returns 
+     */
     get_nearest_active_keypoint(global_x, global_y, max_dist, candidates = null) {
         var ret = {
             "annid": null,
@@ -17318,11 +17326,11 @@ class ULabel {
     }
 
     /**
-     * Get the distance to various types of annotations
+     * Get annotation segment to a point.
      * @param {*} global_x 
      * @param {*} global_y 
-     * @param {*} max_dist 
-     * @param {*} candidates 
+     * @param {*} max_dist Maximum distance to search
+     * @param {*} candidates Candidates to search across 
      * @returns 
      */
     get_nearest_segment_point(global_x, global_y, max_dist, candidates = null) {
@@ -18632,10 +18640,10 @@ class ULabel {
     }
 
     /**
-     * Get best candidates for the edit dialog 
-     * @param {*} gblx 
-     * @param {*} gbly 
-     * @param {*} dst_thresh 
+     * Get initial edit candidates with bounding box collisions
+     * @param {*} gblx Global x coordinate 
+     * @param {*} gbly Global y coordinate
+     * @param {*} dst_thresh Threshold to adjust boxes by 
      * @returns 
      */
     get_edit_candidates(gblx, gbly, dst_thresh) {
@@ -18690,7 +18698,11 @@ class ULabel {
     }
 
     /** 
-     * Find the best candidate for opening the global edit
+     * Suggest edit candidates based on mouse position
+     * Workflow is as follows:
+     * Find annotations where cursor is within bounding box
+     * Find closest keypoints (ends of polygons/polylines etc) within a range defined by the edit handle
+     * If no endpoints, search along segments with infinite range 
      */  
     suggest_edits(mouse_event = null, nonspatial_id = null) {
         let best_candidate;

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -17282,7 +17282,7 @@ class ULabel {
                     npi = geometric_utils/* GeometricUtils.get_nearest_point_on_polygon */.Z.get_nearest_point_on_polygon(
                         global_x, global_y,
                         this.subtasks[this.state["current_subtask"]]["annotations"]["access"][edid]["spatial_payload"],
-                        ret['distance'], true
+                        max_dist, false
                     );
                     if (npi["distance"] < ret["distance"]) {
                         ret["annid"] = edid;
@@ -17350,7 +17350,7 @@ class ULabel {
                     var npi = geometric_utils/* GeometricUtils.get_nearest_point_on_polygon */.Z.get_nearest_point_on_polygon(
                         global_x, global_y,
                         this.subtasks[this.state["current_subtask"]]["annotations"]["access"][edid]["spatial_payload"],
-                        ret['distance'], false
+                        max_dist / this.get_empirical_scale(), false
                     );
                     if (npi["distance"] != null && npi["distance"] < ret["distance"]) {
                         ret["annid"] = edid;

--- a/src/index.js
+++ b/src/index.js
@@ -4201,7 +4201,6 @@ export class ULabel {
             }
 
             const dst_thresh = this.config["edit_handle_size"] / 2;
-            // const dst_thresh = this.config["image_width"];
             const global_x = this.get_global_mouse_x(mouse_event);
             const global_y = this.get_global_mouse_y(mouse_event);
 

--- a/src/index.js
+++ b/src/index.js
@@ -2734,6 +2734,7 @@ export class ULabel {
             "annid": null,
             "access": null,
             "distance": max_dist / this.get_empirical_scale(),
+            // "distance": Infinity,
             "point": null
         };
         if (candidates == null) {
@@ -2782,7 +2783,7 @@ export class ULabel {
                     npi = GeometricUtils.get_nearest_point_on_polygon(
                         global_x, global_y,
                         this.subtasks[this.state["current_subtask"]]["annotations"]["access"][edid]["spatial_payload"],
-                        max_dist, false
+                        ret['distance'], true
                     );
                     if (npi["distance"] < ret["distance"]) {
                         ret["annid"] = edid;
@@ -2818,11 +2819,20 @@ export class ULabel {
         return ret;
     }
 
+    /**
+     * Get the distance to various types of annotations
+     * @param {*} global_x 
+     * @param {*} global_y 
+     * @param {*} max_dist 
+     * @param {*} candidates 
+     * @returns 
+     */
     get_nearest_segment_point(global_x, global_y, max_dist, candidates = null) {
         var ret = {
             "annid": null,
             "access": null,
             "distance": max_dist / this.get_empirical_scale(),
+            // "distance": Infinity,
             "point": null
         };
         if (candidates == null) {
@@ -2841,7 +2851,7 @@ export class ULabel {
                     var npi = GeometricUtils.get_nearest_point_on_polygon(
                         global_x, global_y,
                         this.subtasks[this.state["current_subtask"]]["annotations"]["access"][edid]["spatial_payload"],
-                        max_dist / this.get_empirical_scale(), true
+                        ret['distance'], false
                     );
                     if (npi["distance"] != null && npi["distance"] < ret["distance"]) {
                         ret["annid"] = edid;
@@ -4124,6 +4134,13 @@ export class ULabel {
         this.update_frame(diffZ);
     }
 
+    /**
+     * Get best candidates for the edit dialog 
+     * @param {*} gblx 
+     * @param {*} gbly 
+     * @param {*} dst_thresh 
+     * @returns 
+     */
     get_edit_candidates(gblx, gbly, dst_thresh) {
         dst_thresh /= this.get_empirical_scale();
         let ret = {
@@ -4172,9 +4189,13 @@ export class ULabel {
                 }
             }
         }
+        console.log(ret["candidate_ids"].length);
         return ret;
     }
 
+    /** 
+     * Find the best candidate for opening the global edit
+     */  
     suggest_edits(mouse_event = null, nonspatial_id = null) {
         let best_candidate;
         if (nonspatial_id == null) {
@@ -4183,6 +4204,7 @@ export class ULabel {
             }
 
             const dst_thresh = this.config["edit_handle_size"] / 2;
+            // const dst_thresh = this.config["image_width"];
             const global_x = this.get_global_mouse_x(mouse_event);
             const global_y = this.get_global_mouse_y(mouse_event);
 
@@ -4203,6 +4225,7 @@ export class ULabel {
 
             // Look for an existing point that's close enough to suggest editing it
             const nearest_active_keypoint = this.get_nearest_active_keypoint(global_x, global_y, dst_thresh, edit_candidates["candidate_ids"]);
+            console.log(nearest_active_keypoint)
             if (nearest_active_keypoint != null && nearest_active_keypoint.point != null) {
                 this.subtasks[this.state["current_subtask"]]["state"]["edit_candidate"] = nearest_active_keypoint;
                 this.show_edit_suggestion(nearest_active_keypoint, true);

--- a/src/index.js
+++ b/src/index.js
@@ -2783,7 +2783,7 @@ export class ULabel {
                     npi = GeometricUtils.get_nearest_point_on_polygon(
                         global_x, global_y,
                         this.subtasks[this.state["current_subtask"]]["annotations"]["access"][edid]["spatial_payload"],
-                        ret['distance'], true
+                        max_dist, false
                     );
                     if (npi["distance"] < ret["distance"]) {
                         ret["annid"] = edid;
@@ -2851,7 +2851,7 @@ export class ULabel {
                     var npi = GeometricUtils.get_nearest_point_on_polygon(
                         global_x, global_y,
                         this.subtasks[this.state["current_subtask"]]["annotations"]["access"][edid]["spatial_payload"],
-                        ret['distance'], false
+                        max_dist / this.get_empirical_scale(), false
                     );
                     if (npi["distance"] != null && npi["distance"] < ret["distance"]) {
                         ret["annid"] = edid;

--- a/src/index.js
+++ b/src/index.js
@@ -2734,7 +2734,6 @@ export class ULabel {
             "annid": null,
             "access": null,
             "distance": max_dist / this.get_empirical_scale(),
-            // "distance": Infinity,
             "point": null
         };
         if (candidates == null) {
@@ -2831,8 +2830,7 @@ export class ULabel {
         var ret = {
             "annid": null,
             "access": null,
-            "distance": Infinity,
-            // "distance": Infinity,
+            "distance": max_dist / this.get_empirical_scale(),
             "point": null
         };
         if (candidates == null) {
@@ -2851,7 +2849,7 @@ export class ULabel {
                     var npi = GeometricUtils.get_nearest_point_on_polygon(
                         global_x, global_y,
                         this.subtasks[this.state["current_subtask"]]["annotations"]["access"][edid]["spatial_payload"],
-                        Infinity, true
+                        max_dist / this.get_empirical_scale(), true
                     );
                     if (npi["distance"] != null && npi["distance"] < ret["distance"]) {
                         ret["annid"] = edid;
@@ -4189,7 +4187,6 @@ export class ULabel {
                 }
             }
         }
-        console.log(ret["candidate_ids"].length);
         return ret;
     }
 
@@ -4231,7 +4228,7 @@ export class ULabel {
                 edit_candidates["best"] = nearest_active_keypoint;
             }
             else { // If none are found, look for a point along a segment that's close enough
-                const nearest_segment_point = this.get_nearest_segment_point(global_x, global_y, dst_thresh, edit_candidates["candidate_ids"]);
+                const nearest_segment_point = this.get_nearest_segment_point(global_x, global_y, Infinity, edit_candidates["candidate_ids"]);
                 if (nearest_segment_point != null && nearest_segment_point.point != null) {
                     this.subtasks[this.state["current_subtask"]]["state"]["edit_candidate"] = nearest_segment_point;
                     this.show_edit_suggestion(nearest_segment_point, false);

--- a/src/index.js
+++ b/src/index.js
@@ -2831,7 +2831,7 @@ export class ULabel {
         var ret = {
             "annid": null,
             "access": null,
-            "distance": max_dist / this.get_empirical_scale(),
+            "distance": Infinity,
             // "distance": Infinity,
             "point": null
         };
@@ -2851,7 +2851,7 @@ export class ULabel {
                     var npi = GeometricUtils.get_nearest_point_on_polygon(
                         global_x, global_y,
                         this.subtasks[this.state["current_subtask"]]["annotations"]["access"][edid]["spatial_payload"],
-                        max_dist / this.get_empirical_scale(), false
+                        Infinity, true
                     );
                     if (npi["distance"] != null && npi["distance"] < ret["distance"]) {
                         ret["annid"] = edid;
@@ -4225,7 +4225,6 @@ export class ULabel {
 
             // Look for an existing point that's close enough to suggest editing it
             const nearest_active_keypoint = this.get_nearest_active_keypoint(global_x, global_y, dst_thresh, edit_candidates["candidate_ids"]);
-            console.log(nearest_active_keypoint)
             if (nearest_active_keypoint != null && nearest_active_keypoint.point != null) {
                 this.subtasks[this.state["current_subtask"]]["state"]["edit_candidate"] = nearest_active_keypoint;
                 this.show_edit_suggestion(nearest_active_keypoint, true);

--- a/src/index.js
+++ b/src/index.js
@@ -2729,6 +2729,14 @@ export class ULabel {
     }
 
 
+    /**
+     * Get the annotation with nearest active keypoint (e.g. corners for a bbox, endpoints for polylines) to a point
+     * @param {*} global_x 
+     * @param {*} global_y 
+     * @param {*} max_dist Maximum distance to search
+     * @param {*} candidates Candidates to search across
+     * @returns 
+     */
     get_nearest_active_keypoint(global_x, global_y, max_dist, candidates = null) {
         var ret = {
             "annid": null,
@@ -2819,11 +2827,11 @@ export class ULabel {
     }
 
     /**
-     * Get the distance to various types of annotations
+     * Get annotation segment to a point.
      * @param {*} global_x 
      * @param {*} global_y 
-     * @param {*} max_dist 
-     * @param {*} candidates 
+     * @param {*} max_dist Maximum distance to search
+     * @param {*} candidates Candidates to search across 
      * @returns 
      */
     get_nearest_segment_point(global_x, global_y, max_dist, candidates = null) {
@@ -4133,10 +4141,10 @@ export class ULabel {
     }
 
     /**
-     * Get best candidates for the edit dialog 
-     * @param {*} gblx 
-     * @param {*} gbly 
-     * @param {*} dst_thresh 
+     * Get initial edit candidates with bounding box collisions
+     * @param {*} gblx Global x coordinate 
+     * @param {*} gbly Global y coordinate
+     * @param {*} dst_thresh Threshold to adjust boxes by 
      * @returns 
      */
     get_edit_candidates(gblx, gbly, dst_thresh) {
@@ -4191,7 +4199,11 @@ export class ULabel {
     }
 
     /** 
-     * Find the best candidate for opening the global edit
+     * Suggest edit candidates based on mouse position
+     * Workflow is as follows:
+     * Find annotations where cursor is within bounding box
+     * Find closest keypoints (ends of polygons/polylines etc) within a range defined by the edit handle
+     * If no endpoints, search along segments with infinite range 
      */  
     suggest_edits(mouse_event = null, nonspatial_id = null) {
         let best_candidate;


### PR DESCRIPTION
# better edit candidates
## Description
Previous workflow was:

- Find annotations where cursor is within bounding box
- Find closest keypoints (ends of polygons/polylines etc) within a range defined by the edit handle
- If no endpoints, search along segments within a range defined by the edit handle

Change was to remove the range on the last point, so if not within range of a keypoint, search along all segments.
The issue was that the second two steps wouldn't produce anything as the range was too small to be relevant, so removing it for the second case solves some hovering irregularities.

Might need a future rework.

## PR Checklist

- [ ] Merged latest main
- [ ] Version number in `package.json` has been bumped since last release
- [ ] Version numbers match between package `package.json` and `src/version.js`
- [ ] Ran `npm install` and `npm run build` AFTER bumping the version number
- [ ] Updated documentation if necessary (currently just in `api_spec.md`)
- [ ] Added changes to `changelog.md`

## Breaking API Changes

Broke things being broken
