### PR TITLE
Fixed KeypointSliderItem passing in incorrect parameter

### DIFF
--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -20159,7 +20159,7 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         _this.check_for_human_deprecated(current_subtask);
         //check the config to see if we should update the annotations with the default filter on load
         if (ulabel.config.filter_annotations_on_load) {
-            _this.deprecate_annotations(current_subtask, _this.default_value);
+            _this.deprecate_annotations(ulabel, _this.default_value);
         }
         //The annotations are drawn for the first time after the toolbox is loaded
         //so we don't actually have to redraw the annotations after deprecating them.

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -20159,7 +20159,7 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         _this.check_for_human_deprecated(current_subtask);
         //check the config to see if we should update the annotations with the default filter on load
         if (ulabel.config.filter_annotations_on_load) {
-            _this.deprecate_annotations(ulabel, _this.default_value, true);
+            _this.deprecate_annotations(ulabel, _this.default_value, false);
         }
         //The annotations are drawn for the first time after the toolbox is loaded
         //so we don't actually have to redraw the annotations after deprecating them.
@@ -20169,8 +20169,8 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         });
         return _this;
     }
-    KeypointSliderItem.prototype.deprecate_annotations = function (ulabel, filter_value, from_constructor) {
-        if (from_constructor === void 0) { from_constructor = false; }
+    KeypointSliderItem.prototype.deprecate_annotations = function (ulabel, filter_value, redraw) {
+        if (redraw === void 0) { redraw = true; }
         //get the current subtask
         var current_subtask_key = ulabel.state["current_subtask"];
         var current_subtask = ulabel.subtasks[current_subtask_key];
@@ -20191,7 +20191,7 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         //Update the slider bar's position, and the label's text.
         $("#" + this.slider_bar_id).val(Math.round(filter_value * 100));
         $("#" + this.slider_bar_id + "-label").text(Math.round(filter_value * 100) + "%");
-        if (!from_constructor) {
+        if (redraw) {
             ulabel.redraw_all_annotations(null, null, false);
         }
     };

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -20140,7 +20140,7 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         _this.slider_bar_id = _this.name.replaceAll(" ", "-").toLowerCase();
         //if the config has a default value override, then use that instead
         if (ulabel.config.hasOwnProperty(_this.name.replaceAll(" ", "_").toLowerCase() + "_default_value")) {
-            kwargs._default_value = ulabel.config[_this.name.split(" ").join("_").toLowerCase() + "_default_value"];
+            kwargs.default_value = ulabel.config[_this.name.split(" ").join("_").toLowerCase() + "_default_value"];
         }
         //if this keypoint slider has a generic default, then use it
         //otherwise the defalut is 0
@@ -20159,7 +20159,7 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         _this.check_for_human_deprecated(current_subtask);
         //check the config to see if we should update the annotations with the default filter on load
         if (ulabel.config.filter_annotations_on_load) {
-            _this.deprecate_annotations(ulabel, _this.default_value);
+            _this.deprecate_annotations(ulabel, _this.default_value, true);
         }
         //The annotations are drawn for the first time after the toolbox is loaded
         //so we don't actually have to redraw the annotations after deprecating them.
@@ -20169,7 +20169,8 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         });
         return _this;
     }
-    KeypointSliderItem.prototype.deprecate_annotations = function (ulabel, filter_value) {
+    KeypointSliderItem.prototype.deprecate_annotations = function (ulabel, filter_value, from_constructor) {
+        if (from_constructor === void 0) { from_constructor = false; }
         //get the current subtask
         var current_subtask_key = ulabel.state["current_subtask"];
         var current_subtask = ulabel.subtasks[current_subtask_key];
@@ -20190,7 +20191,9 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         //Update the slider bar's position, and the label's text.
         $("#" + this.slider_bar_id).val(Math.round(filter_value * 100));
         $("#" + this.slider_bar_id + "-label").text(Math.round(filter_value * 100) + "%");
-        ulabel.redraw_all_annotations(null, null, false);
+        if (!from_constructor) {
+            ulabel.redraw_all_annotations(null, null, false);
+        }
     };
     //if an annotation is deprecated and has a child, then assume its human deprecated.
     KeypointSliderItem.prototype.check_for_human_deprecated = function (current_subtask) {

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -595,7 +595,7 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         _this.check_for_human_deprecated(current_subtask);
         //check the config to see if we should update the annotations with the default filter on load
         if (ulabel.config.filter_annotations_on_load) {
-            _this.deprecate_annotations(ulabel, _this.default_value, true);
+            _this.deprecate_annotations(ulabel, _this.default_value, false);
         }
         //The annotations are drawn for the first time after the toolbox is loaded
         //so we don't actually have to redraw the annotations after deprecating them.
@@ -605,8 +605,8 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         });
         return _this;
     }
-    KeypointSliderItem.prototype.deprecate_annotations = function (ulabel, filter_value, from_constructor) {
-        if (from_constructor === void 0) { from_constructor = false; }
+    KeypointSliderItem.prototype.deprecate_annotations = function (ulabel, filter_value, redraw) {
+        if (redraw === void 0) { redraw = true; }
         //get the current subtask
         var current_subtask_key = ulabel.state["current_subtask"];
         var current_subtask = ulabel.subtasks[current_subtask_key];
@@ -627,7 +627,7 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         //Update the slider bar's position, and the label's text.
         $("#" + this.slider_bar_id).val(Math.round(filter_value * 100));
         $("#" + this.slider_bar_id + "-label").text(Math.round(filter_value * 100) + "%");
-        if (!from_constructor) {
+        if (redraw) {
             ulabel.redraw_all_annotations(null, null, false);
         }
     };

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -576,7 +576,7 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         _this.slider_bar_id = _this.name.replaceAll(" ", "-").toLowerCase();
         //if the config has a default value override, then use that instead
         if (ulabel.config.hasOwnProperty(_this.name.replaceAll(" ", "_").toLowerCase() + "_default_value")) {
-            kwargs._default_value = ulabel.config[_this.name.split(" ").join("_").toLowerCase() + "_default_value"];
+            kwargs.default_value = ulabel.config[_this.name.split(" ").join("_").toLowerCase() + "_default_value"];
         }
         //if this keypoint slider has a generic default, then use it
         //otherwise the defalut is 0
@@ -595,7 +595,7 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         _this.check_for_human_deprecated(current_subtask);
         //check the config to see if we should update the annotations with the default filter on load
         if (ulabel.config.filter_annotations_on_load) {
-            _this.deprecate_annotations(ulabel, _this.default_value);
+            _this.deprecate_annotations(ulabel, _this.default_value, true);
         }
         //The annotations are drawn for the first time after the toolbox is loaded
         //so we don't actually have to redraw the annotations after deprecating them.
@@ -605,7 +605,8 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         });
         return _this;
     }
-    KeypointSliderItem.prototype.deprecate_annotations = function (ulabel, filter_value) {
+    KeypointSliderItem.prototype.deprecate_annotations = function (ulabel, filter_value, from_constructor) {
+        if (from_constructor === void 0) { from_constructor = false; }
         //get the current subtask
         var current_subtask_key = ulabel.state["current_subtask"];
         var current_subtask = ulabel.subtasks[current_subtask_key];
@@ -626,7 +627,9 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         //Update the slider bar's position, and the label's text.
         $("#" + this.slider_bar_id).val(Math.round(filter_value * 100));
         $("#" + this.slider_bar_id + "-label").text(Math.round(filter_value * 100) + "%");
-        ulabel.redraw_all_annotations(null, null, false);
+        if (!from_constructor) {
+            ulabel.redraw_all_annotations(null, null, false);
+        }
     };
     //if an annotation is deprecated and has a child, then assume its human deprecated.
     KeypointSliderItem.prototype.check_for_human_deprecated = function (current_subtask) {

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -595,7 +595,7 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         _this.check_for_human_deprecated(current_subtask);
         //check the config to see if we should update the annotations with the default filter on load
         if (ulabel.config.filter_annotations_on_load) {
-            _this.deprecate_annotations(current_subtask, _this.default_value);
+            _this.deprecate_annotations(ulabel, _this.default_value);
         }
         //The annotations are drawn for the first time after the toolbox is loaded
         //so we don't actually have to redraw the annotations after deprecating them.

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -798,7 +798,7 @@ export class KeypointSliderItem extends ToolboxItem {
 
         //check the config to see if we should update the annotations with the default filter on load
         if (ulabel.config.filter_annotations_on_load) {
-            this.deprecate_annotations(current_subtask, this.default_value);
+            this.deprecate_annotations(ulabel, this.default_value);
         }
 
         //The annotations are drawn for the first time after the toolbox is loaded

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -774,7 +774,7 @@ export class KeypointSliderItem extends ToolboxItem {
         
         //if the config has a default value override, then use that instead
         if (ulabel.config.hasOwnProperty(this.name.replaceAll(" ","_").toLowerCase() + "_default_value")) {
-            kwargs._default_value = ulabel.config[this.name.split(" ").join("_").toLowerCase() + "_default_value"];
+            kwargs.default_value = ulabel.config[this.name.split(" ").join("_").toLowerCase() + "_default_value"];
         }
 
         //if this keypoint slider has a generic default, then use it
@@ -798,7 +798,7 @@ export class KeypointSliderItem extends ToolboxItem {
 
         //check the config to see if we should update the annotations with the default filter on load
         if (ulabel.config.filter_annotations_on_load) {
-            this.deprecate_annotations(ulabel, this.default_value);
+            this.deprecate_annotations(ulabel, this.default_value, true);
         }
 
         //The annotations are drawn for the first time after the toolbox is loaded
@@ -810,7 +810,7 @@ export class KeypointSliderItem extends ToolboxItem {
         })
     }
 
-    public deprecate_annotations(ulabel, filter_value) {
+    public deprecate_annotations(ulabel, filter_value, from_constructor = false) {
 
         //get the current subtask
         let current_subtask_key = ulabel.state["current_subtask"];
@@ -838,7 +838,9 @@ export class KeypointSliderItem extends ToolboxItem {
         $("#" + this.slider_bar_id).val(Math.round(filter_value * 100));
         $("#" + this.slider_bar_id + "-label").text(Math.round(filter_value * 100) + "%");
 
-        ulabel.redraw_all_annotations(null, null, false);
+        if (!from_constructor) {
+            ulabel.redraw_all_annotations(null, null, false);
+        }
     }
 
     //if an annotation is deprecated and has a child, then assume its human deprecated.

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -798,7 +798,7 @@ export class KeypointSliderItem extends ToolboxItem {
 
         //check the config to see if we should update the annotations with the default filter on load
         if (ulabel.config.filter_annotations_on_load) {
-            this.deprecate_annotations(ulabel, this.default_value, true);
+            this.deprecate_annotations(ulabel, this.default_value, false);
         }
 
         //The annotations are drawn for the first time after the toolbox is loaded
@@ -810,7 +810,7 @@ export class KeypointSliderItem extends ToolboxItem {
         })
     }
 
-    public deprecate_annotations(ulabel, filter_value, from_constructor = false) {
+    public deprecate_annotations(ulabel, filter_value, redraw: boolean = true) {
 
         //get the current subtask
         let current_subtask_key = ulabel.state["current_subtask"];
@@ -838,7 +838,7 @@ export class KeypointSliderItem extends ToolboxItem {
         $("#" + this.slider_bar_id).val(Math.round(filter_value * 100));
         $("#" + this.slider_bar_id + "-label").text(Math.round(filter_value * 100) + "%");
 
-        if (!from_constructor) {
+        if (redraw) {
             ulabel.redraw_all_annotations(null, null, false);
         }
     }


### PR DESCRIPTION
# Fixed KeypointSliderItem passing in incorrect parameter to deprecate_annotations

## Description

Page wouldn't load if the keypoint slider tried to run deprecate_annotations on load. This is because it was passing an incorrect parameter to deprecate_annotations. This is now fixed

## PR Checklist

- [ ] Merged latest main
- [ ] Version number in `package.json` has been bumped since last release
- [ ] Version numbers match between package `package.json` and `src/version.js`
- [ ] Ran `npm install` and `npm run build` AFTER bumping the version number
- [ ] Updated documentation if necessary (currently just in `api_spec.md`)
- [ ] Added changes to `changelog.md`

## Breaking API Changes

none
