### PR TITLE
Vanish all

### DIFF
--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -19605,17 +19605,16 @@ exports.KeypointSliderItem = exports.RecolorActiveItem = exports.AnnotationResiz
 var __1 = __webpack_require__(318);
 var configuration_1 = __webpack_require__(976);
 var toolboxDividerDiv = "<div class=toolbox-divider></div>";
-/** Chains the replaceAll method and the toLowerCase method  */
+/** Chains the replaceAll method and the toLowerCase method.
+ *  Optionally concatenates a string at the end of the method.
+  */
 String.prototype.replaceLowerConcat = function (before, after, concat_string) {
     if (concat_string === void 0) { concat_string = null; }
-    this.replaceAll(before, after);
-    this.toLowerCase();
     if (typeof (concat_string) === "string") {
-        return this.concat(concat_string);
+        return this.replaceAll(before, after).toLowerCase().concat(concat_string);
     }
-    return this;
+    return this.replaceAll(before, after).toLowerCase();
 };
-"this".replaceLowerConcat(" ", "-");
 /**
  * Manager for toolbox. Contains ToolboxTab items.
  */
@@ -19888,25 +19887,26 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         var vanish_size = 0.01;
         if (subtask == null)
             return;
+        var subtask_vanished_flag = subtask.display_name.replaceLowerConcat(" ", "-", "-vanished");
         //If the annotations are currently vanished and a button other than the vanish button is
         //pressed, then we want to ignore the input
-        if (this[subtask.display_name.replaceLowerConcat(" ", "-") + "-vanished"] && size !== "v")
+        if (this[subtask_vanished_flag] && size !== "v")
             return;
         if (typeof (size) === "number") {
             this.loop_through_annotations(subtask, size, "=");
         }
         if (size == "v") {
-            if (this[subtask.display_name.replaceLowerConcat(" ", "-") + "-vanished"]) {
+            if (this[subtask_vanished_flag]) {
                 this.loop_through_annotations(subtask, this.cached_size, "=");
                 //flip the bool state
-                this[subtask.display_name.replaceLowerConcat(" ", "-") + "-vanished"] = !this[subtask.display_name.replaceLowerConcat(" ", "-") + "-vanished"];
+                this[subtask_vanished_flag] = !this[subtask_vanished_flag];
                 $("#annotation-resize-v").attr("style", "background-color: " + "rgba(100, 148, 237, 0.8)");
                 return;
             }
-            if (this[subtask.display_name.replaceLowerConcat(" ", "-") + "-vanished"] !== true) {
+            if (!this[subtask_vanished_flag]) {
                 this.loop_through_annotations(subtask, vanish_size, "=");
                 //flip the bool state
-                this[subtask.display_name.replaceLowerConcat(" ", "-") + "-vanished"] = !this[subtask.display_name.replaceLowerConcat(" ", "-") + "-vanished"];
+                this[subtask_vanished_flag] = !this[subtask_vanished_flag];
                 $("#annotation-resize-v").attr("style", "background-color: " + "#1c2d4d");
                 return;
             }
@@ -20177,8 +20177,8 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         _this.mark_deprecated = kwargs.mark_deprecated;
         _this.slider_bar_id = _this.name.replaceLowerConcat(" ", "-");
         //if the config has a default value override, then use that instead
-        if (ulabel.config.hasOwnProperty(_this.name.replaceLowerConcat(" ", "_") + "_default_value")) {
-            kwargs.default_value = ulabel.config[_this.name.replaceLowerConcat(" ", "_") + "_default_value"];
+        if (ulabel.config.hasOwnProperty(_this.name.replaceLowerConcat(" ", "_", "_default_value"))) {
+            kwargs.default_value = ulabel.config[_this.name.replaceLowerConcat(" ", "_", "_default_value")];
         }
         //if this keypoint slider has a generic default, then use it
         //otherwise the defalut is 0
@@ -20279,7 +20279,8 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         }
     };
     KeypointSliderItem.prototype.get_html = function () {
-        return "\n        <div class=\"keypoint-slider\">\n            <p class=\"tb-header\">".concat(this.name, "</p>\n            <div class=\"keypoint-slider-holder\">\n                <input \n                    type=\"range\" \n                    id=\"").concat(this.name.replaceLowerConcat(" ", "-"), "\" \n                    class=\"keypoint-slider\" value=\"").concat(this.default_value * 100, "\"\n                />\n                <label \n                    for=\"").concat(this.name.replaceLowerConcat(" ", "-"), "\" \n                    id=\"").concat(this.name.replaceLowerConcat(" ", "-"), "-label\"\n                    class=\"keypoint-slider-label\">\n                    ").concat(Math.round(this.default_value * 100), "%\n                </label>\n                <span class=\"increment\" >\n                    <a href=\"#\" class=\"button inc keypoint-slider-increment ").concat(this.name.replaceLowerConcat(" ", "-"), "-button\" >+</a>\n                    <a href=\"#\" class=\"button dec keypoint-slider-increment ").concat(this.name.replaceLowerConcat(" ", "-"), "-button\" >-</a>\n                </span>\n            </div>\n        </div>");
+        var component_name = this.name.replaceLowerConcat(" ", "-");
+        return "\n        <div class=\"keypoint-slider\">\n            <p class=\"tb-header\">".concat(this.name, "</p>\n            <div class=\"keypoint-slider-holder\">\n                <input \n                    type=\"range\" \n                    id=\"").concat(component_name, "\" \n                    class=\"keypoint-slider\" value=\"").concat(this.default_value * 100, "\"\n                />\n                <label \n                    for=\"").concat(component_name, "\" \n                    id=\"").concat(component_name, "-label\"\n                    class=\"keypoint-slider-label\">\n                    ").concat(Math.round(this.default_value * 100), "%\n                </label>\n                <span class=\"increment\" >\n                    <a href=\"#\" class=\"button inc keypoint-slider-increment ").concat(component_name, "-button\" >+</a>\n                    <a href=\"#\" class=\"button dec keypoint-slider-increment ").concat(component_name, "-button\" >-</a>\n                </span>\n            </div>\n        </div>");
     };
     return KeypointSliderItem;
 }(ToolboxItem));

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -19828,7 +19828,6 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         //First check for a size cookie, if one isn't found then check the config
         //for a default annotation size. If neither are found it will use the size
         //that the annotation was saved as.
-        console.log(_this.read_size_cookie(current_subtask));
         if (_this.read_size_cookie(current_subtask) != null) {
             _this.update_annotation_size(current_subtask, Number(_this.read_size_cookie(current_subtask)));
         }

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -19605,9 +19605,11 @@ exports.KeypointSliderItem = exports.RecolorActiveItem = exports.AnnotationResiz
 var __1 = __webpack_require__(318);
 var configuration_1 = __webpack_require__(976);
 var toolboxDividerDiv = "<div class=toolbox-divider></div>";
-function read_annotation_confidence() {
-    return;
-}
+String.prototype.replaceLower = function (before, after) {
+    this.replaceAll(before, after);
+    this.toLowerCase();
+    return this;
+};
 /**
  * Manager for toolbox. Contains ToolboxTab items.
  */
@@ -19882,23 +19884,23 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
             return;
         //If the annotations are currently vanished and a button other than the vanish button is
         //pressed, then we want to ignore the input
-        if (this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"] && size !== "v")
+        if (this[subtask.display_name.replaceLower(" ", "-") + "-vanished"] && size !== "v")
             return;
         if (typeof (size) === "number") {
             this.loop_through_annotations(subtask, size, "=");
         }
         if (size == "v") {
-            if (this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"]) {
+            if (this[subtask.display_name.replaceLower(" ", "-") + "-vanished"]) {
                 this.loop_through_annotations(subtask, this.cached_size, "=");
                 //flip the bool state
-                this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"] = !this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"];
+                this[subtask.display_name.replaceLower(" ", "-") + "-vanished"] = !this[subtask.display_name.replaceLower(" ", "-") + "-vanished"];
                 $("#annotation-resize-v").attr("style", "background-color: " + "rgba(100, 148, 237, 0.8)");
                 return;
             }
-            if (this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"] !== true) {
+            if (this[subtask.display_name.replaceLower(" ", "-") + "-vanished"] !== true) {
                 this.loop_through_annotations(subtask, vanish_size, "=");
                 //flip the bool state
-                this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"] = !this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"];
+                this[subtask.display_name.replaceLower(" ", "-") + "-vanished"] = !this[subtask.display_name.replaceLower(" ", "-") + "-vanished"];
                 $("#annotation-resize-v").attr("style", "background-color: " + "#1c2d4d");
                 return;
             }
@@ -19968,11 +19970,11 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
     AnnotationResizeItem.prototype.set_size_cookie = function (cookie_value, subtask) {
         var d = new Date();
         d.setTime(d.getTime() + (10000 * 24 * 60 * 60 * 1000));
-        var subtask_name = subtask.display_name.replaceAll(" ", "_").toLowerCase();
+        var subtask_name = subtask.display_name.replaceLower(" ", "_");
         document.cookie = subtask_name + "_size=" + cookie_value + ";" + d.toUTCString() + ";path=/";
     };
     AnnotationResizeItem.prototype.read_size_cookie = function (subtask) {
-        var subtask_name = subtask.display_name.replaceAll(" ", "_").toLowerCase();
+        var subtask_name = subtask.display_name.replaceLower(" ", "_");
         var cookie_name = subtask_name + "_size=";
         var cookie_array = document.cookie.split(";");
         for (var i = 0; i < cookie_array.length; i++) {
@@ -20167,10 +20169,10 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         _this.filter_function = kwargs.filter_function;
         _this.get_confidence = kwargs.confidence_function;
         _this.mark_deprecated = kwargs.mark_deprecated;
-        _this.slider_bar_id = _this.name.replaceAll(" ", "-").toLowerCase();
+        _this.slider_bar_id = _this.name.replaceLower(" ", "-");
         //if the config has a default value override, then use that instead
-        if (ulabel.config.hasOwnProperty(_this.name.replaceAll(" ", "_").toLowerCase() + "_default_value")) {
-            kwargs.default_value = ulabel.config[_this.name.split(" ").join("_").toLowerCase() + "_default_value"];
+        if (ulabel.config.hasOwnProperty(_this.name.replaceLower(" ", "_") + "_default_value")) {
+            kwargs.default_value = ulabel.config[_this.name.replaceLower(" ", "_") + "_default_value"];
         }
         //if this keypoint slider has a generic default, then use it
         //otherwise the defalut is 0
@@ -20193,13 +20195,13 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         }
         //The annotations are drawn for the first time after the toolbox is loaded
         //so we don't actually have to redraw the annotations after deprecating them.
-        $(document).on("input", "#" + _this.name.replaceAll(" ", "-").toLowerCase(), function (e) {
+        $(document).on("input", "#" + _this.name.replaceLower(" ", "-"), function (e) {
             var filter_value = e.currentTarget.value / 100;
             _this.deprecate_annotations(ulabel, filter_value);
         });
-        $(document).on("click", "a." + _this.name.replaceAll(" ", "-").toLowerCase() + "-button", function (e) {
+        $(document).on("click", "a." + _this.name.replaceLower(" ", "-") + "-button", function (e) {
             var button_text = e.currentTarget.outerText;
-            var slider = document.getElementById(_this.name.replaceAll(" ", "-").toLowerCase());
+            var slider = document.getElementById(_this.name.replaceLower(" ", "-"));
             if (button_text == "+") {
                 slider.value = (slider.valueAsNumber + 1).toString();
             }
@@ -20217,11 +20219,11 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         //event listener for keybinds
         $(document).on("keypress", function (e) {
             if (e.key == kwargs.keybinds.increment) {
-                var button = document.getElementsByClassName(_this.name.replaceAll(" ", "-").toLowerCase() + "-button inc")[0];
+                var button = document.getElementsByClassName(_this.name.replaceLower(" ", "-") + "-button inc")[0];
                 button.click();
             }
             if (e.key == kwargs.keybinds.decrement) {
-                var button = document.getElementsByClassName(_this.name.replaceAll(" ", "-").toLowerCase() + "-button dec")[0];
+                var button = document.getElementsByClassName(_this.name.replaceLower(" ", "-") + "-button dec")[0];
                 button.click();
             }
         });
@@ -20271,7 +20273,7 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         }
     };
     KeypointSliderItem.prototype.get_html = function () {
-        return "\n        <div class=\"keypoint-slider\">\n            <p class=\"tb-header\">".concat(this.name, "</p>\n            <div class=\"keypoint-slider-holder\">\n                <input \n                    type=\"range\" \n                    id=\"").concat(this.name.replaceAll(" ", "-").toLowerCase(), "\" \n                    class=\"keypoint-slider\" value=\"").concat(this.default_value * 100, "\"\n                />\n                <label \n                    for=\"").concat(this.name.replaceAll(" ", "-").toLowerCase(), "\" \n                    id=\"").concat(this.name.replaceAll(" ", "-").toLowerCase(), "-label\"\n                    class=\"keypoint-slider-label\">\n                    ").concat(Math.round(this.default_value * 100), "%\n                </label>\n                <span class=\"increment\" >\n                    <a href=\"#\" class=\"button inc keypoint-slider-increment ").concat(this.name.replaceAll(" ", "-").toLowerCase(), "-button\" >+</a>\n                    <a href=\"#\" class=\"button dec keypoint-slider-increment ").concat(this.name.replaceAll(" ", "-").toLowerCase(), "-button\" >-</a>\n                </span>\n            </div>\n        </div>");
+        return "\n        <div class=\"keypoint-slider\">\n            <p class=\"tb-header\">".concat(this.name, "</p>\n            <div class=\"keypoint-slider-holder\">\n                <input \n                    type=\"range\" \n                    id=\"").concat(this.name.replaceLower(" ", "-"), "\" \n                    class=\"keypoint-slider\" value=\"").concat(this.default_value * 100, "\"\n                />\n                <label \n                    for=\"").concat(this.name.replaceLower(" ", "-"), "\" \n                    id=\"").concat(this.name.replaceLower(" ", "-"), "-label\"\n                    class=\"keypoint-slider-label\">\n                    ").concat(Math.round(this.default_value * 100), "%\n                </label>\n                <span class=\"increment\" >\n                    <a href=\"#\" class=\"button inc keypoint-slider-increment ").concat(this.name.replaceLower(" ", "-"), "-button\" >+</a>\n                    <a href=\"#\" class=\"button dec keypoint-slider-increment ").concat(this.name.replaceLower(" ", "-"), "-button\" >-</a>\n                </span>\n            </div>\n        </div>");
     };
     return KeypointSliderItem;
 }(ToolboxItem));

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -19825,21 +19825,22 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         var _this = _super.call(this) || this;
         _this.cached_size = 1.5;
         _this.inner_HTML = "<p class=\"tb-header\">Annotation Count</p>";
+        console.log(document.cookie);
         //get default keybinds
         _this.keybind_configuration = ulabel.config.default_keybinds;
-        //update cased size to default
-        _this.cached_size = ulabel.config.default_annotation_size;
         //grab current subtask for convinience
         var current_subtask_key = ulabel.state["current_subtask"];
         var current_subtask = ulabel.subtasks[current_subtask_key];
         //First check for a size cookie, if one isn't found then check the config
         //for a default annotation size. If neither are found it will use the size
         //that the annotation was saved as.
-        if (_this.read_size_cookie(current_subtask) != null) {
-            _this.update_annotation_size(current_subtask, Number(_this.read_size_cookie(current_subtask)));
-        }
-        else if (ulabel.config.default_annotation_size != undefined) {
-            _this.update_annotation_size(current_subtask, ulabel.config.default_annotation_size);
+        for (var subtask in ulabel.subtasks) {
+            if (_this.read_size_cookie(ulabel.subtasks[subtask]) != null) {
+                _this.update_annotation_size(ulabel.subtasks[subtask], Number(_this.read_size_cookie(ulabel.subtasks[subtask])));
+            }
+            else if (ulabel.config.default_annotation_size != undefined) {
+                _this.update_annotation_size(ulabel.subtasks[subtask], ulabel.config.default_annotation_size);
+            }
         }
         //event listener for buttons
         $(document).on("click", "a.butt-ann", function (e) {
@@ -19885,6 +19886,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         var large_size = 5;
         var increment_size = 0.5;
         var vanish_size = 0.01;
+        var subtask_cashed_size = subtask.display_name.replaceLowerConcat(" ", "-", "-cashed-size");
         if (subtask == null)
             return;
         var subtask_vanished_flag = subtask.display_name.replaceLowerConcat(" ", "-", "-vanished");
@@ -19897,7 +19899,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         }
         if (size == "v") {
             if (this[subtask_vanished_flag]) {
-                this.loop_through_annotations(subtask, this.cached_size, "=");
+                this.loop_through_annotations(subtask, this[subtask_cashed_size], "=");
                 //flip the bool state
                 this[subtask_vanished_flag] = !this[subtask_vanished_flag];
                 $("#annotation-resize-v").attr("style", "background-color: " + "rgba(100, 148, 237, 0.8)");
@@ -19915,11 +19917,11 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         switch (size) {
             case 's':
                 this.loop_through_annotations(subtask, small_size, "=");
-                this.cached_size = small_size;
+                this[subtask_cashed_size] = small_size;
                 break;
             case 'l':
                 this.loop_through_annotations(subtask, large_size, "=");
-                this.cached_size = large_size;
+                this[subtask_cashed_size] = large_size;
                 break;
             case 'dec':
                 this.loop_through_annotations(subtask, increment_size, "-");
@@ -19933,6 +19935,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
     };
     //loops through all annotations in a subtask to change their line size
     AnnotationResizeItem.prototype.loop_through_annotations = function (subtask, size, operation) {
+        var subtask_cashed_size = subtask.display_name.replaceLowerConcat(" ", "-", "-cashed-size");
         if (operation == "=") {
             for (var annotation_id in subtask.annotations.access) {
                 subtask.annotations.access[annotation_id].line_size = size;
@@ -19944,7 +19947,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
             for (var annotation_id in subtask.annotations.access) {
                 subtask.annotations.access[annotation_id].line_size += size;
                 //temporary solution
-                this.cached_size = subtask.annotations.access[annotation_id].line_size;
+                this[subtask_cashed_size] = subtask.annotations.access[annotation_id].line_size;
             }
             this.set_size_cookie(subtask.annotations.access[subtask.annotations.ordering[0]].line_size, subtask);
             return;
@@ -19960,7 +19963,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
                     subtask.annotations.access[annotation_id].line_size -= size;
                 }
                 //temporary solution
-                this.cached_size = subtask.annotations.access[annotation_id].line_size;
+                this[subtask_cashed_size] = subtask.annotations.access[annotation_id].line_size;
             }
             this.set_size_cookie(subtask.annotations.access[subtask.annotations.ordering[0]].line_size, subtask);
             return;
@@ -19980,6 +19983,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         document.cookie = subtask_name + "_size=" + cookie_value + ";" + d.toUTCString() + ";path=/";
     };
     AnnotationResizeItem.prototype.read_size_cookie = function (subtask) {
+        console.log(subtask, "Read Size Cookie");
         var subtask_name = subtask.display_name.replaceLowerConcat(" ", "_");
         var cookie_name = subtask_name + "_size=";
         var cookie_array = document.cookie.split(";");

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -19849,6 +19849,9 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
             var current_subtask = ulabel.subtasks[current_subtask_key];
             console.log(e.key);
             switch (e.key) {
+                case _this.keybind_configuration.annotation_vanish.toUpperCase():
+                    _this.update_all_subtask_annotation_size(ulabel, "v");
+                    break;
                 case _this.keybind_configuration.annotation_vanish:
                     _this.update_annotation_size(current_subtask, "v");
                     break;
@@ -19956,6 +19959,13 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
             return;
         }
         throw Error("Invalid Operation given to loop_through_annotations");
+    };
+    AnnotationResizeItem.prototype.update_all_subtask_annotation_size = function (ulabel, size) {
+        console.log(ulabel);
+        for (var subtask in ulabel.subtasks) {
+            console.log(subtask);
+            this.update_annotation_size(ulabel.subtasks[subtask], size);
+        }
     };
     AnnotationResizeItem.prototype.set_size_cookie = function (cookie_value, subtask) {
         var d = new Date();

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -19825,7 +19825,6 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         var _this = _super.call(this) || this;
         _this.cached_size = 1.5;
         _this.inner_HTML = "<p class=\"tb-header\">Annotation Count</p>";
-        console.log(document.cookie);
         //get default keybinds
         _this.keybind_configuration = ulabel.config.default_keybinds;
         //grab current subtask for convinience
@@ -19838,25 +19837,19 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
             var cashed_size_property = ulabel.subtasks[subtask].display_name.replaceLowerConcat(" ", "-", "-cashed-size");
             var size_cookie = _this.read_size_cookie(ulabel.subtasks[subtask]);
             if ((size_cookie != null) && size_cookie != "NaN") {
-                console.log(size_cookie, size_cookie != "NaN");
                 _this.update_annotation_size(ulabel.subtasks[subtask], Number(size_cookie));
-                console.log(size_cookie, "inside constructor", subtask);
                 _this[cashed_size_property] = Number(size_cookie);
             }
             else if (ulabel.config.default_annotation_size != undefined) {
                 _this.update_annotation_size(ulabel.subtasks[subtask], ulabel.config.default_annotation_size);
                 _this[cashed_size_property] = ulabel.config.default_annotation_size;
-                console.log(_this.read_size_cookie(ulabel.subtasks[subtask]), "inside constructor", subtask, 2);
             }
             else {
                 var DEFAULT_SIZE = 5;
                 _this.update_annotation_size(ulabel.subtasks[subtask], DEFAULT_SIZE);
                 _this[cashed_size_property] = DEFAULT_SIZE;
-                console.log(_this.read_size_cookie(ulabel.subtasks[subtask]), "inside constructor", subtask, 3);
             }
         }
-        console.log(document.cookie);
-        console.log(ulabel);
         //event listener for buttons
         $(document).on("click", "a.butt-ann", function (e) {
             var button = $(e.currentTarget);
@@ -19889,10 +19882,6 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
                 case _this.keybind_configuration.annotation_size_plus:
                     _this.update_annotation_size(current_subtask, "inc");
                     break;
-                default:
-                    for (var subtask in ulabel.subtasks) {
-                        console.log(_this[ulabel.subtasks[subtask].display_name.replaceLowerConcat(" ", "-", "-cashed-size")], ulabel.subtasks[subtask].display_name.replaceLowerConcat(" ", "-", "-cashed-size"));
-                    }
             }
             ulabel.redraw_all_annotations(null, null, false);
         });
@@ -19906,9 +19895,6 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         var increment_size = 0.5;
         var vanish_size = 0.01;
         var subtask_cashed_size = subtask.display_name.replaceLowerConcat(" ", "-", "-cashed-size");
-        if (size == "v") {
-            console.log(this[subtask_cashed_size], subtask);
-        }
         if (subtask == null)
             return;
         var subtask_vanished_flag = subtask.display_name.replaceLowerConcat(" ", "-", "-vanished");
@@ -19967,7 +19953,6 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         }
         if (operation == "+") {
             for (var annotation_id in subtask.annotations.access) {
-                console.log(subtask.annotations.access[annotation_id].line_size);
                 subtask.annotations.access[annotation_id].line_size += size;
                 //temporary solution
                 this[subtask_cashed_size] = subtask.annotations.access[annotation_id].line_size;
@@ -20006,7 +19991,6 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         document.cookie = subtask_name + "_size=" + cookie_value + ";" + d.toUTCString() + ";path=/";
     };
     AnnotationResizeItem.prototype.read_size_cookie = function (subtask) {
-        console.log(subtask, "Read Size Cookie");
         var subtask_name = subtask.display_name.replaceLowerConcat(" ", "_");
         var cookie_name = subtask_name + "_size=";
         var cookie_array = document.cookie.split(";");

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -19605,11 +19605,17 @@ exports.KeypointSliderItem = exports.RecolorActiveItem = exports.AnnotationResiz
 var __1 = __webpack_require__(318);
 var configuration_1 = __webpack_require__(976);
 var toolboxDividerDiv = "<div class=toolbox-divider></div>";
-String.prototype.replaceLower = function (before, after) {
+/** Chains the replaceAll method and the toLowerCase method  */
+String.prototype.replaceLowerConcat = function (before, after, concat_string) {
+    if (concat_string === void 0) { concat_string = null; }
     this.replaceAll(before, after);
     this.toLowerCase();
+    if (typeof (concat_string) === "string") {
+        return this.concat(concat_string);
+    }
     return this;
 };
+"this".replaceLowerConcat(" ", "-");
 /**
  * Manager for toolbox. Contains ToolboxTab items.
  */
@@ -19884,23 +19890,23 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
             return;
         //If the annotations are currently vanished and a button other than the vanish button is
         //pressed, then we want to ignore the input
-        if (this[subtask.display_name.replaceLower(" ", "-") + "-vanished"] && size !== "v")
+        if (this[subtask.display_name.replaceLowerConcat(" ", "-") + "-vanished"] && size !== "v")
             return;
         if (typeof (size) === "number") {
             this.loop_through_annotations(subtask, size, "=");
         }
         if (size == "v") {
-            if (this[subtask.display_name.replaceLower(" ", "-") + "-vanished"]) {
+            if (this[subtask.display_name.replaceLowerConcat(" ", "-") + "-vanished"]) {
                 this.loop_through_annotations(subtask, this.cached_size, "=");
                 //flip the bool state
-                this[subtask.display_name.replaceLower(" ", "-") + "-vanished"] = !this[subtask.display_name.replaceLower(" ", "-") + "-vanished"];
+                this[subtask.display_name.replaceLowerConcat(" ", "-") + "-vanished"] = !this[subtask.display_name.replaceLowerConcat(" ", "-") + "-vanished"];
                 $("#annotation-resize-v").attr("style", "background-color: " + "rgba(100, 148, 237, 0.8)");
                 return;
             }
-            if (this[subtask.display_name.replaceLower(" ", "-") + "-vanished"] !== true) {
+            if (this[subtask.display_name.replaceLowerConcat(" ", "-") + "-vanished"] !== true) {
                 this.loop_through_annotations(subtask, vanish_size, "=");
                 //flip the bool state
-                this[subtask.display_name.replaceLower(" ", "-") + "-vanished"] = !this[subtask.display_name.replaceLower(" ", "-") + "-vanished"];
+                this[subtask.display_name.replaceLowerConcat(" ", "-") + "-vanished"] = !this[subtask.display_name.replaceLowerConcat(" ", "-") + "-vanished"];
                 $("#annotation-resize-v").attr("style", "background-color: " + "#1c2d4d");
                 return;
             }
@@ -19970,11 +19976,11 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
     AnnotationResizeItem.prototype.set_size_cookie = function (cookie_value, subtask) {
         var d = new Date();
         d.setTime(d.getTime() + (10000 * 24 * 60 * 60 * 1000));
-        var subtask_name = subtask.display_name.replaceLower(" ", "_");
+        var subtask_name = subtask.display_name.replaceLowerConcat(" ", "_");
         document.cookie = subtask_name + "_size=" + cookie_value + ";" + d.toUTCString() + ";path=/";
     };
     AnnotationResizeItem.prototype.read_size_cookie = function (subtask) {
-        var subtask_name = subtask.display_name.replaceLower(" ", "_");
+        var subtask_name = subtask.display_name.replaceLowerConcat(" ", "_");
         var cookie_name = subtask_name + "_size=";
         var cookie_array = document.cookie.split(";");
         for (var i = 0; i < cookie_array.length; i++) {
@@ -20169,10 +20175,10 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         _this.filter_function = kwargs.filter_function;
         _this.get_confidence = kwargs.confidence_function;
         _this.mark_deprecated = kwargs.mark_deprecated;
-        _this.slider_bar_id = _this.name.replaceLower(" ", "-");
+        _this.slider_bar_id = _this.name.replaceLowerConcat(" ", "-");
         //if the config has a default value override, then use that instead
-        if (ulabel.config.hasOwnProperty(_this.name.replaceLower(" ", "_") + "_default_value")) {
-            kwargs.default_value = ulabel.config[_this.name.replaceLower(" ", "_") + "_default_value"];
+        if (ulabel.config.hasOwnProperty(_this.name.replaceLowerConcat(" ", "_") + "_default_value")) {
+            kwargs.default_value = ulabel.config[_this.name.replaceLowerConcat(" ", "_") + "_default_value"];
         }
         //if this keypoint slider has a generic default, then use it
         //otherwise the defalut is 0
@@ -20195,13 +20201,13 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         }
         //The annotations are drawn for the first time after the toolbox is loaded
         //so we don't actually have to redraw the annotations after deprecating them.
-        $(document).on("input", "#" + _this.name.replaceLower(" ", "-"), function (e) {
+        $(document).on("input", "#" + _this.name.replaceLowerConcat(" ", "-"), function (e) {
             var filter_value = e.currentTarget.value / 100;
             _this.deprecate_annotations(ulabel, filter_value);
         });
-        $(document).on("click", "a." + _this.name.replaceLower(" ", "-") + "-button", function (e) {
+        $(document).on("click", "a." + _this.name.replaceLowerConcat(" ", "-") + "-button", function (e) {
             var button_text = e.currentTarget.outerText;
-            var slider = document.getElementById(_this.name.replaceLower(" ", "-"));
+            var slider = document.getElementById(_this.name.replaceLowerConcat(" ", "-"));
             if (button_text == "+") {
                 slider.value = (slider.valueAsNumber + 1).toString();
             }
@@ -20219,11 +20225,11 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         //event listener for keybinds
         $(document).on("keypress", function (e) {
             if (e.key == kwargs.keybinds.increment) {
-                var button = document.getElementsByClassName(_this.name.replaceLower(" ", "-") + "-button inc")[0];
+                var button = document.getElementsByClassName(_this.name.replaceLowerConcat(" ", "-") + "-button inc")[0];
                 button.click();
             }
             if (e.key == kwargs.keybinds.decrement) {
-                var button = document.getElementsByClassName(_this.name.replaceLower(" ", "-") + "-button dec")[0];
+                var button = document.getElementsByClassName(_this.name.replaceLowerConcat(" ", "-") + "-button dec")[0];
                 button.click();
             }
         });
@@ -20273,7 +20279,7 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         }
     };
     KeypointSliderItem.prototype.get_html = function () {
-        return "\n        <div class=\"keypoint-slider\">\n            <p class=\"tb-header\">".concat(this.name, "</p>\n            <div class=\"keypoint-slider-holder\">\n                <input \n                    type=\"range\" \n                    id=\"").concat(this.name.replaceLower(" ", "-"), "\" \n                    class=\"keypoint-slider\" value=\"").concat(this.default_value * 100, "\"\n                />\n                <label \n                    for=\"").concat(this.name.replaceLower(" ", "-"), "\" \n                    id=\"").concat(this.name.replaceLower(" ", "-"), "-label\"\n                    class=\"keypoint-slider-label\">\n                    ").concat(Math.round(this.default_value * 100), "%\n                </label>\n                <span class=\"increment\" >\n                    <a href=\"#\" class=\"button inc keypoint-slider-increment ").concat(this.name.replaceLower(" ", "-"), "-button\" >+</a>\n                    <a href=\"#\" class=\"button dec keypoint-slider-increment ").concat(this.name.replaceLower(" ", "-"), "-button\" >-</a>\n                </span>\n            </div>\n        </div>");
+        return "\n        <div class=\"keypoint-slider\">\n            <p class=\"tb-header\">".concat(this.name, "</p>\n            <div class=\"keypoint-slider-holder\">\n                <input \n                    type=\"range\" \n                    id=\"").concat(this.name.replaceLowerConcat(" ", "-"), "\" \n                    class=\"keypoint-slider\" value=\"").concat(this.default_value * 100, "\"\n                />\n                <label \n                    for=\"").concat(this.name.replaceLowerConcat(" ", "-"), "\" \n                    id=\"").concat(this.name.replaceLowerConcat(" ", "-"), "-label\"\n                    class=\"keypoint-slider-label\">\n                    ").concat(Math.round(this.default_value * 100), "%\n                </label>\n                <span class=\"increment\" >\n                    <a href=\"#\" class=\"button inc keypoint-slider-increment ").concat(this.name.replaceLowerConcat(" ", "-"), "-button\" >+</a>\n                    <a href=\"#\" class=\"button dec keypoint-slider-increment ").concat(this.name.replaceLowerConcat(" ", "-"), "-button\" >-</a>\n                </span>\n            </div>\n        </div>");
     };
     return KeypointSliderItem;
 }(ToolboxItem));

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -19820,6 +19820,8 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         _this.inner_HTML = "<p class=\"tb-header\">Annotation Count</p>";
         //get default keybinds
         _this.keybind_configuration = ulabel.config.default_keybinds;
+        //update cased size to default
+        _this.cached_size = ulabel.config.default_annotation_size;
         //grab current subtask for convinience
         var current_subtask_key = ulabel.state["current_subtask"];
         var current_subtask = ulabel.subtasks[current_subtask_key];

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -19834,20 +19834,20 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         //for a default annotation size. If neither are found it will use the size
         //that the annotation was saved as.
         for (var subtask in ulabel.subtasks) {
-            var cashed_size_property = ulabel.subtasks[subtask].display_name.replaceLowerConcat(" ", "-", "-cashed-size");
+            var cached_size_property = ulabel.subtasks[subtask].display_name.replaceLowerConcat(" ", "-", "-cached-size");
             var size_cookie = _this.read_size_cookie(ulabel.subtasks[subtask]);
             if ((size_cookie != null) && size_cookie != "NaN") {
                 _this.update_annotation_size(ulabel.subtasks[subtask], Number(size_cookie));
-                _this[cashed_size_property] = Number(size_cookie);
+                _this[cached_size_property] = Number(size_cookie);
             }
             else if (ulabel.config.default_annotation_size != undefined) {
                 _this.update_annotation_size(ulabel.subtasks[subtask], ulabel.config.default_annotation_size);
-                _this[cashed_size_property] = ulabel.config.default_annotation_size;
+                _this[cached_size_property] = ulabel.config.default_annotation_size;
             }
             else {
                 var DEFAULT_SIZE = 5;
                 _this.update_annotation_size(ulabel.subtasks[subtask], DEFAULT_SIZE);
-                _this[cashed_size_property] = DEFAULT_SIZE;
+                _this[cached_size_property] = DEFAULT_SIZE;
             }
         }
         //event listener for buttons
@@ -19894,7 +19894,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         var large_size = 5;
         var increment_size = 0.5;
         var vanish_size = 0.01;
-        var subtask_cashed_size = subtask.display_name.replaceLowerConcat(" ", "-", "-cashed-size");
+        var subtask_cached_size = subtask.display_name.replaceLowerConcat(" ", "-", "-cached-size");
         if (subtask == null)
             return;
         var subtask_vanished_flag = subtask.display_name.replaceLowerConcat(" ", "-", "-vanished");
@@ -19907,7 +19907,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         }
         if (size == "v") {
             if (this[subtask_vanished_flag]) {
-                this.loop_through_annotations(subtask, this[subtask_cashed_size], "=");
+                this.loop_through_annotations(subtask, this[subtask_cached_size], "=");
                 //flip the bool state
                 this[subtask_vanished_flag] = !this[subtask_vanished_flag];
                 $("#annotation-resize-v").attr("style", "background-color: " + "rgba(100, 148, 237, 0.8)");
@@ -19925,11 +19925,11 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         switch (size) {
             case 's':
                 this.loop_through_annotations(subtask, small_size, "=");
-                this[subtask_cashed_size] = small_size;
+                this[subtask_cached_size] = small_size;
                 break;
             case 'l':
                 this.loop_through_annotations(subtask, large_size, "=");
-                this[subtask_cashed_size] = large_size;
+                this[subtask_cached_size] = large_size;
                 break;
             case 'dec':
                 this.loop_through_annotations(subtask, increment_size, "-");
@@ -19943,7 +19943,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
     };
     //loops through all annotations in a subtask to change their line size
     AnnotationResizeItem.prototype.loop_through_annotations = function (subtask, size, operation) {
-        var subtask_cashed_size = subtask.display_name.replaceLowerConcat(" ", "-", "-cashed-size");
+        var subtask_cached_size = subtask.display_name.replaceLowerConcat(" ", "-", "-cached-size");
         if (operation == "=") {
             for (var annotation_id in subtask.annotations.access) {
                 subtask.annotations.access[annotation_id].line_size = size;
@@ -19955,7 +19955,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
             for (var annotation_id in subtask.annotations.access) {
                 subtask.annotations.access[annotation_id].line_size += size;
                 //temporary solution
-                this[subtask_cashed_size] = subtask.annotations.access[annotation_id].line_size;
+                this[subtask_cached_size] = subtask.annotations.access[annotation_id].line_size;
             }
             this.set_size_cookie(subtask.annotations.access[subtask.annotations.ordering[0]].line_size, subtask);
             return;
@@ -19971,7 +19971,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
                     subtask.annotations.access[annotation_id].line_size -= size;
                 }
                 //temporary solution
-                this[subtask_cashed_size] = subtask.annotations.access[annotation_id].line_size;
+                this[subtask_cached_size] = subtask.annotations.access[annotation_id].line_size;
             }
             this.set_size_cookie(subtask.annotations.access[subtask.annotations.ordering[0]].line_size, subtask);
             return;

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -19847,7 +19847,6 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         $(document).on("keypress", function (e) {
             var current_subtask_key = ulabel.state["current_subtask"];
             var current_subtask = ulabel.subtasks[current_subtask_key];
-            console.log(e.key);
             switch (e.key) {
                 case _this.keybind_configuration.annotation_vanish.toUpperCase():
                     _this.update_all_subtask_annotation_size(ulabel, "v");
@@ -19960,10 +19959,9 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         }
         throw Error("Invalid Operation given to loop_through_annotations");
     };
+    //Loop through all subtasks and apply a size to them all
     AnnotationResizeItem.prototype.update_all_subtask_annotation_size = function (ulabel, size) {
-        console.log(ulabel);
         for (var subtask in ulabel.subtasks) {
-            console.log(subtask);
             this.update_annotation_size(ulabel.subtasks[subtask], size);
         }
     };

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -19835,13 +19835,28 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         //for a default annotation size. If neither are found it will use the size
         //that the annotation was saved as.
         for (var subtask in ulabel.subtasks) {
-            if (_this.read_size_cookie(ulabel.subtasks[subtask]) != null) {
-                _this.update_annotation_size(ulabel.subtasks[subtask], Number(_this.read_size_cookie(ulabel.subtasks[subtask])));
+            var cashed_size_property = ulabel.subtasks[subtask].display_name.replaceLowerConcat(" ", "-", "-cashed-size");
+            var size_cookie = _this.read_size_cookie(ulabel.subtasks[subtask]);
+            if ((size_cookie != null) && size_cookie != "NaN") {
+                console.log(size_cookie, size_cookie != "NaN");
+                _this.update_annotation_size(ulabel.subtasks[subtask], Number(size_cookie));
+                console.log(size_cookie, "inside constructor", subtask);
+                _this[cashed_size_property] = Number(size_cookie);
             }
             else if (ulabel.config.default_annotation_size != undefined) {
                 _this.update_annotation_size(ulabel.subtasks[subtask], ulabel.config.default_annotation_size);
+                _this[cashed_size_property] = ulabel.config.default_annotation_size;
+                console.log(_this.read_size_cookie(ulabel.subtasks[subtask]), "inside constructor", subtask, 2);
+            }
+            else {
+                var DEFAULT_SIZE = 5;
+                _this.update_annotation_size(ulabel.subtasks[subtask], DEFAULT_SIZE);
+                _this[cashed_size_property] = DEFAULT_SIZE;
+                console.log(_this.read_size_cookie(ulabel.subtasks[subtask]), "inside constructor", subtask, 3);
             }
         }
+        console.log(document.cookie);
+        console.log(ulabel);
         //event listener for buttons
         $(document).on("click", "a.butt-ann", function (e) {
             var button = $(e.currentTarget);
@@ -19874,6 +19889,10 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
                 case _this.keybind_configuration.annotation_size_plus:
                     _this.update_annotation_size(current_subtask, "inc");
                     break;
+                default:
+                    for (var subtask in ulabel.subtasks) {
+                        console.log(_this[ulabel.subtasks[subtask].display_name.replaceLowerConcat(" ", "-", "-cashed-size")], ulabel.subtasks[subtask].display_name.replaceLowerConcat(" ", "-", "-cashed-size"));
+                    }
             }
             ulabel.redraw_all_annotations(null, null, false);
         });
@@ -19887,6 +19906,9 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         var increment_size = 0.5;
         var vanish_size = 0.01;
         var subtask_cashed_size = subtask.display_name.replaceLowerConcat(" ", "-", "-cashed-size");
+        if (size == "v") {
+            console.log(this[subtask_cashed_size], subtask);
+        }
         if (subtask == null)
             return;
         var subtask_vanished_flag = subtask.display_name.replaceLowerConcat(" ", "-", "-vanished");
@@ -19945,6 +19967,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         }
         if (operation == "+") {
             for (var annotation_id in subtask.annotations.access) {
+                console.log(subtask.annotations.access[annotation_id].line_size);
                 subtask.annotations.access[annotation_id].line_size += size;
                 //temporary solution
                 this[subtask_cashed_size] = subtask.annotations.access[annotation_id].line_size;

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -19816,7 +19816,6 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
     __extends(AnnotationResizeItem, _super);
     function AnnotationResizeItem(ulabel) {
         var _this = _super.call(this) || this;
-        _this.is_vanished = false;
         _this.cached_size = 1.5;
         _this.inner_HTML = "<p class=\"tb-header\">Annotation Count</p>";
         //get default keybinds
@@ -19883,23 +19882,23 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
             return;
         //If the annotations are currently vanished and a button other than the vanish button is
         //pressed, then we want to ignore the input
-        if (this.is_vanished && size !== "v")
+        if (this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"] && size !== "v")
             return;
         if (typeof (size) === "number") {
             this.loop_through_annotations(subtask, size, "=");
         }
         if (size == "v") {
-            if (this.is_vanished) {
+            if (this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"]) {
                 this.loop_through_annotations(subtask, this.cached_size, "=");
                 //flip the bool state
-                this.is_vanished = !this.is_vanished;
+                this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"] = !this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"];
                 $("#annotation-resize-v").attr("style", "background-color: " + "rgba(100, 148, 237, 0.8)");
                 return;
             }
-            if (this.is_vanished !== true) {
+            if (this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"] !== true) {
                 this.loop_through_annotations(subtask, vanish_size, "=");
                 //flip the bool state
-                this.is_vanished = !this.is_vanished;
+                this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"] = !this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"];
                 $("#annotation-resize-v").attr("style", "background-color: " + "#1c2d4d");
                 return;
             }

--- a/index.d.ts
+++ b/index.d.ts
@@ -93,6 +93,6 @@ export class ULabel {
     
 declare global {
     interface String {
-    replaceLower(before: String, after: String): string
+    replaceLowerConcat(before: string, after: string, concat_string?: string): string
     }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -91,3 +91,8 @@ export class ULabel {
         
     }
     
+declare global {
+    interface String {
+    replaceLower(before: String, after: String): string
+    }
+}

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -239,7 +239,6 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         var _this = _super.call(this) || this;
         _this.cached_size = 1.5;
         _this.inner_HTML = "<p class=\"tb-header\">Annotation Count</p>";
-        console.log(document.cookie);
         //get default keybinds
         _this.keybind_configuration = ulabel.config.default_keybinds;
         //grab current subtask for convinience
@@ -252,25 +251,19 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
             var cashed_size_property = ulabel.subtasks[subtask].display_name.replaceLowerConcat(" ", "-", "-cashed-size");
             var size_cookie = _this.read_size_cookie(ulabel.subtasks[subtask]);
             if ((size_cookie != null) && size_cookie != "NaN") {
-                console.log(size_cookie, size_cookie != "NaN");
                 _this.update_annotation_size(ulabel.subtasks[subtask], Number(size_cookie));
-                console.log(size_cookie, "inside constructor", subtask);
                 _this[cashed_size_property] = Number(size_cookie);
             }
             else if (ulabel.config.default_annotation_size != undefined) {
                 _this.update_annotation_size(ulabel.subtasks[subtask], ulabel.config.default_annotation_size);
                 _this[cashed_size_property] = ulabel.config.default_annotation_size;
-                console.log(_this.read_size_cookie(ulabel.subtasks[subtask]), "inside constructor", subtask, 2);
             }
             else {
                 var DEFAULT_SIZE = 5;
                 _this.update_annotation_size(ulabel.subtasks[subtask], DEFAULT_SIZE);
                 _this[cashed_size_property] = DEFAULT_SIZE;
-                console.log(_this.read_size_cookie(ulabel.subtasks[subtask]), "inside constructor", subtask, 3);
             }
         }
-        console.log(document.cookie);
-        console.log(ulabel);
         //event listener for buttons
         $(document).on("click", "a.butt-ann", function (e) {
             var button = $(e.currentTarget);
@@ -303,10 +296,6 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
                 case _this.keybind_configuration.annotation_size_plus:
                     _this.update_annotation_size(current_subtask, "inc");
                     break;
-                default:
-                    for (var subtask in ulabel.subtasks) {
-                        console.log(_this[ulabel.subtasks[subtask].display_name.replaceLowerConcat(" ", "-", "-cashed-size")], ulabel.subtasks[subtask].display_name.replaceLowerConcat(" ", "-", "-cashed-size"));
-                    }
             }
             ulabel.redraw_all_annotations(null, null, false);
         });
@@ -320,9 +309,6 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         var increment_size = 0.5;
         var vanish_size = 0.01;
         var subtask_cashed_size = subtask.display_name.replaceLowerConcat(" ", "-", "-cashed-size");
-        if (size == "v") {
-            console.log(this[subtask_cashed_size], subtask);
-        }
         if (subtask == null)
             return;
         var subtask_vanished_flag = subtask.display_name.replaceLowerConcat(" ", "-", "-vanished");
@@ -381,7 +367,6 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         }
         if (operation == "+") {
             for (var annotation_id in subtask.annotations.access) {
-                console.log(subtask.annotations.access[annotation_id].line_size);
                 subtask.annotations.access[annotation_id].line_size += size;
                 //temporary solution
                 this[subtask_cashed_size] = subtask.annotations.access[annotation_id].line_size;
@@ -420,7 +405,6 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         document.cookie = subtask_name + "_size=" + cookie_value + ";" + d.toUTCString() + ";path=/";
     };
     AnnotationResizeItem.prototype.read_size_cookie = function (subtask) {
-        console.log(subtask, "Read Size Cookie");
         var subtask_name = subtask.display_name.replaceLowerConcat(" ", "_");
         var cookie_name = subtask_name + "_size=";
         var cookie_array = document.cookie.split(";");

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -239,21 +239,22 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         var _this = _super.call(this) || this;
         _this.cached_size = 1.5;
         _this.inner_HTML = "<p class=\"tb-header\">Annotation Count</p>";
+        console.log(document.cookie);
         //get default keybinds
         _this.keybind_configuration = ulabel.config.default_keybinds;
-        //update cased size to default
-        _this.cached_size = ulabel.config.default_annotation_size;
         //grab current subtask for convinience
         var current_subtask_key = ulabel.state["current_subtask"];
         var current_subtask = ulabel.subtasks[current_subtask_key];
         //First check for a size cookie, if one isn't found then check the config
         //for a default annotation size. If neither are found it will use the size
         //that the annotation was saved as.
-        if (_this.read_size_cookie(current_subtask) != null) {
-            _this.update_annotation_size(current_subtask, Number(_this.read_size_cookie(current_subtask)));
-        }
-        else if (ulabel.config.default_annotation_size != undefined) {
-            _this.update_annotation_size(current_subtask, ulabel.config.default_annotation_size);
+        for (var subtask in ulabel.subtasks) {
+            if (_this.read_size_cookie(ulabel.subtasks[subtask]) != null) {
+                _this.update_annotation_size(ulabel.subtasks[subtask], Number(_this.read_size_cookie(ulabel.subtasks[subtask])));
+            }
+            else if (ulabel.config.default_annotation_size != undefined) {
+                _this.update_annotation_size(ulabel.subtasks[subtask], ulabel.config.default_annotation_size);
+            }
         }
         //event listener for buttons
         $(document).on("click", "a.butt-ann", function (e) {
@@ -299,6 +300,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         var large_size = 5;
         var increment_size = 0.5;
         var vanish_size = 0.01;
+        var subtask_cashed_size = subtask.display_name.replaceLowerConcat(" ", "-", "-cashed-size");
         if (subtask == null)
             return;
         var subtask_vanished_flag = subtask.display_name.replaceLowerConcat(" ", "-", "-vanished");
@@ -311,7 +313,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         }
         if (size == "v") {
             if (this[subtask_vanished_flag]) {
-                this.loop_through_annotations(subtask, this.cached_size, "=");
+                this.loop_through_annotations(subtask, this[subtask_cashed_size], "=");
                 //flip the bool state
                 this[subtask_vanished_flag] = !this[subtask_vanished_flag];
                 $("#annotation-resize-v").attr("style", "background-color: " + "rgba(100, 148, 237, 0.8)");
@@ -329,11 +331,11 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         switch (size) {
             case 's':
                 this.loop_through_annotations(subtask, small_size, "=");
-                this.cached_size = small_size;
+                this[subtask_cashed_size] = small_size;
                 break;
             case 'l':
                 this.loop_through_annotations(subtask, large_size, "=");
-                this.cached_size = large_size;
+                this[subtask_cashed_size] = large_size;
                 break;
             case 'dec':
                 this.loop_through_annotations(subtask, increment_size, "-");
@@ -347,6 +349,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
     };
     //loops through all annotations in a subtask to change their line size
     AnnotationResizeItem.prototype.loop_through_annotations = function (subtask, size, operation) {
+        var subtask_cashed_size = subtask.display_name.replaceLowerConcat(" ", "-", "-cashed-size");
         if (operation == "=") {
             for (var annotation_id in subtask.annotations.access) {
                 subtask.annotations.access[annotation_id].line_size = size;
@@ -358,7 +361,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
             for (var annotation_id in subtask.annotations.access) {
                 subtask.annotations.access[annotation_id].line_size += size;
                 //temporary solution
-                this.cached_size = subtask.annotations.access[annotation_id].line_size;
+                this[subtask_cashed_size] = subtask.annotations.access[annotation_id].line_size;
             }
             this.set_size_cookie(subtask.annotations.access[subtask.annotations.ordering[0]].line_size, subtask);
             return;
@@ -374,7 +377,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
                     subtask.annotations.access[annotation_id].line_size -= size;
                 }
                 //temporary solution
-                this.cached_size = subtask.annotations.access[annotation_id].line_size;
+                this[subtask_cashed_size] = subtask.annotations.access[annotation_id].line_size;
             }
             this.set_size_cookie(subtask.annotations.access[subtask.annotations.ordering[0]].line_size, subtask);
             return;
@@ -394,6 +397,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         document.cookie = subtask_name + "_size=" + cookie_value + ";" + d.toUTCString() + ";path=/";
     };
     AnnotationResizeItem.prototype.read_size_cookie = function (subtask) {
+        console.log(subtask, "Read Size Cookie");
         var subtask_name = subtask.display_name.replaceLowerConcat(" ", "_");
         var cookie_name = subtask_name + "_size=";
         var cookie_array = document.cookie.split(";");

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -19,17 +19,16 @@ exports.KeypointSliderItem = exports.RecolorActiveItem = exports.AnnotationResiz
 var __1 = require("..");
 var configuration_1 = require("./configuration");
 var toolboxDividerDiv = "<div class=toolbox-divider></div>";
-/** Chains the replaceAll method and the toLowerCase method  */
+/** Chains the replaceAll method and the toLowerCase method.
+ *  Optionally concatenates a string at the end of the method.
+  */
 String.prototype.replaceLowerConcat = function (before, after, concat_string) {
     if (concat_string === void 0) { concat_string = null; }
-    this.replaceAll(before, after);
-    this.toLowerCase();
     if (typeof (concat_string) === "string") {
-        return this.concat(concat_string);
+        return this.replaceAll(before, after).toLowerCase().concat(concat_string);
     }
-    return this;
+    return this.replaceAll(before, after).toLowerCase();
 };
-"this".replaceLowerConcat(" ", "-");
 /**
  * Manager for toolbox. Contains ToolboxTab items.
  */
@@ -302,25 +301,26 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         var vanish_size = 0.01;
         if (subtask == null)
             return;
+        var subtask_vanished_flag = subtask.display_name.replaceLowerConcat(" ", "-", "-vanished");
         //If the annotations are currently vanished and a button other than the vanish button is
         //pressed, then we want to ignore the input
-        if (this[subtask.display_name.replaceLowerConcat(" ", "-") + "-vanished"] && size !== "v")
+        if (this[subtask_vanished_flag] && size !== "v")
             return;
         if (typeof (size) === "number") {
             this.loop_through_annotations(subtask, size, "=");
         }
         if (size == "v") {
-            if (this[subtask.display_name.replaceLowerConcat(" ", "-") + "-vanished"]) {
+            if (this[subtask_vanished_flag]) {
                 this.loop_through_annotations(subtask, this.cached_size, "=");
                 //flip the bool state
-                this[subtask.display_name.replaceLowerConcat(" ", "-") + "-vanished"] = !this[subtask.display_name.replaceLowerConcat(" ", "-") + "-vanished"];
+                this[subtask_vanished_flag] = !this[subtask_vanished_flag];
                 $("#annotation-resize-v").attr("style", "background-color: " + "rgba(100, 148, 237, 0.8)");
                 return;
             }
-            if (this[subtask.display_name.replaceLowerConcat(" ", "-") + "-vanished"] !== true) {
+            if (!this[subtask_vanished_flag]) {
                 this.loop_through_annotations(subtask, vanish_size, "=");
                 //flip the bool state
-                this[subtask.display_name.replaceLowerConcat(" ", "-") + "-vanished"] = !this[subtask.display_name.replaceLowerConcat(" ", "-") + "-vanished"];
+                this[subtask_vanished_flag] = !this[subtask_vanished_flag];
                 $("#annotation-resize-v").attr("style", "background-color: " + "#1c2d4d");
                 return;
             }
@@ -591,8 +591,8 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         _this.mark_deprecated = kwargs.mark_deprecated;
         _this.slider_bar_id = _this.name.replaceLowerConcat(" ", "-");
         //if the config has a default value override, then use that instead
-        if (ulabel.config.hasOwnProperty(_this.name.replaceLowerConcat(" ", "_") + "_default_value")) {
-            kwargs.default_value = ulabel.config[_this.name.replaceLowerConcat(" ", "_") + "_default_value"];
+        if (ulabel.config.hasOwnProperty(_this.name.replaceLowerConcat(" ", "_", "_default_value"))) {
+            kwargs.default_value = ulabel.config[_this.name.replaceLowerConcat(" ", "_", "_default_value")];
         }
         //if this keypoint slider has a generic default, then use it
         //otherwise the defalut is 0
@@ -693,7 +693,8 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         }
     };
     KeypointSliderItem.prototype.get_html = function () {
-        return "\n        <div class=\"keypoint-slider\">\n            <p class=\"tb-header\">".concat(this.name, "</p>\n            <div class=\"keypoint-slider-holder\">\n                <input \n                    type=\"range\" \n                    id=\"").concat(this.name.replaceLowerConcat(" ", "-"), "\" \n                    class=\"keypoint-slider\" value=\"").concat(this.default_value * 100, "\"\n                />\n                <label \n                    for=\"").concat(this.name.replaceLowerConcat(" ", "-"), "\" \n                    id=\"").concat(this.name.replaceLowerConcat(" ", "-"), "-label\"\n                    class=\"keypoint-slider-label\">\n                    ").concat(Math.round(this.default_value * 100), "%\n                </label>\n                <span class=\"increment\" >\n                    <a href=\"#\" class=\"button inc keypoint-slider-increment ").concat(this.name.replaceLowerConcat(" ", "-"), "-button\" >+</a>\n                    <a href=\"#\" class=\"button dec keypoint-slider-increment ").concat(this.name.replaceLowerConcat(" ", "-"), "-button\" >-</a>\n                </span>\n            </div>\n        </div>");
+        var component_name = this.name.replaceLowerConcat(" ", "-");
+        return "\n        <div class=\"keypoint-slider\">\n            <p class=\"tb-header\">".concat(this.name, "</p>\n            <div class=\"keypoint-slider-holder\">\n                <input \n                    type=\"range\" \n                    id=\"").concat(component_name, "\" \n                    class=\"keypoint-slider\" value=\"").concat(this.default_value * 100, "\"\n                />\n                <label \n                    for=\"").concat(component_name, "\" \n                    id=\"").concat(component_name, "-label\"\n                    class=\"keypoint-slider-label\">\n                    ").concat(Math.round(this.default_value * 100), "%\n                </label>\n                <span class=\"increment\" >\n                    <a href=\"#\" class=\"button inc keypoint-slider-increment ").concat(component_name, "-button\" >+</a>\n                    <a href=\"#\" class=\"button dec keypoint-slider-increment ").concat(component_name, "-button\" >-</a>\n                </span>\n            </div>\n        </div>");
     };
     return KeypointSliderItem;
 }(ToolboxItem));

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -230,7 +230,6 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
     __extends(AnnotationResizeItem, _super);
     function AnnotationResizeItem(ulabel) {
         var _this = _super.call(this) || this;
-        _this.is_vanished = false;
         _this.cached_size = 1.5;
         _this.inner_HTML = "<p class=\"tb-header\">Annotation Count</p>";
         //get default keybinds
@@ -297,23 +296,23 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
             return;
         //If the annotations are currently vanished and a button other than the vanish button is
         //pressed, then we want to ignore the input
-        if (this.is_vanished && size !== "v")
+        if (this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"] && size !== "v")
             return;
         if (typeof (size) === "number") {
             this.loop_through_annotations(subtask, size, "=");
         }
         if (size == "v") {
-            if (this.is_vanished) {
+            if (this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"]) {
                 this.loop_through_annotations(subtask, this.cached_size, "=");
                 //flip the bool state
-                this.is_vanished = !this.is_vanished;
+                this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"] = !this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"];
                 $("#annotation-resize-v").attr("style", "background-color: " + "rgba(100, 148, 237, 0.8)");
                 return;
             }
-            if (this.is_vanished !== true) {
+            if (this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"] !== true) {
                 this.loop_through_annotations(subtask, vanish_size, "=");
                 //flip the bool state
-                this.is_vanished = !this.is_vanished;
+                this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"] = !this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"];
                 $("#annotation-resize-v").attr("style", "background-color: " + "#1c2d4d");
                 return;
             }

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -261,7 +261,6 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         $(document).on("keypress", function (e) {
             var current_subtask_key = ulabel.state["current_subtask"];
             var current_subtask = ulabel.subtasks[current_subtask_key];
-            console.log(e.key);
             switch (e.key) {
                 case _this.keybind_configuration.annotation_vanish.toUpperCase():
                     _this.update_all_subtask_annotation_size(ulabel, "v");
@@ -374,10 +373,9 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         }
         throw Error("Invalid Operation given to loop_through_annotations");
     };
+    //Loop through all subtasks and apply a size to them all
     AnnotationResizeItem.prototype.update_all_subtask_annotation_size = function (ulabel, size) {
-        console.log(ulabel);
         for (var subtask in ulabel.subtasks) {
-            console.log(subtask);
             this.update_annotation_size(ulabel.subtasks[subtask], size);
         }
     };

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -263,6 +263,9 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
             var current_subtask = ulabel.subtasks[current_subtask_key];
             console.log(e.key);
             switch (e.key) {
+                case _this.keybind_configuration.annotation_vanish.toUpperCase():
+                    _this.update_all_subtask_annotation_size(ulabel, "v");
+                    break;
                 case _this.keybind_configuration.annotation_vanish:
                     _this.update_annotation_size(current_subtask, "v");
                     break;
@@ -370,6 +373,13 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
             return;
         }
         throw Error("Invalid Operation given to loop_through_annotations");
+    };
+    AnnotationResizeItem.prototype.update_all_subtask_annotation_size = function (ulabel, size) {
+        console.log(ulabel);
+        for (var subtask in ulabel.subtasks) {
+            console.log(subtask);
+            this.update_annotation_size(ulabel.subtasks[subtask], size);
+        }
     };
     AnnotationResizeItem.prototype.set_size_cookie = function (cookie_value, subtask) {
         var d = new Date();

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -242,7 +242,6 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         //First check for a size cookie, if one isn't found then check the config
         //for a default annotation size. If neither are found it will use the size
         //that the annotation was saved as.
-        console.log(_this.read_size_cookie(current_subtask));
         if (_this.read_size_cookie(current_subtask) != null) {
             _this.update_annotation_size(current_subtask, Number(_this.read_size_cookie(current_subtask)));
         }

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -249,13 +249,28 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         //for a default annotation size. If neither are found it will use the size
         //that the annotation was saved as.
         for (var subtask in ulabel.subtasks) {
-            if (_this.read_size_cookie(ulabel.subtasks[subtask]) != null) {
-                _this.update_annotation_size(ulabel.subtasks[subtask], Number(_this.read_size_cookie(ulabel.subtasks[subtask])));
+            var cashed_size_property = ulabel.subtasks[subtask].display_name.replaceLowerConcat(" ", "-", "-cashed-size");
+            var size_cookie = _this.read_size_cookie(ulabel.subtasks[subtask]);
+            if ((size_cookie != null) && size_cookie != "NaN") {
+                console.log(size_cookie, size_cookie != "NaN");
+                _this.update_annotation_size(ulabel.subtasks[subtask], Number(size_cookie));
+                console.log(size_cookie, "inside constructor", subtask);
+                _this[cashed_size_property] = Number(size_cookie);
             }
             else if (ulabel.config.default_annotation_size != undefined) {
                 _this.update_annotation_size(ulabel.subtasks[subtask], ulabel.config.default_annotation_size);
+                _this[cashed_size_property] = ulabel.config.default_annotation_size;
+                console.log(_this.read_size_cookie(ulabel.subtasks[subtask]), "inside constructor", subtask, 2);
+            }
+            else {
+                var DEFAULT_SIZE = 5;
+                _this.update_annotation_size(ulabel.subtasks[subtask], DEFAULT_SIZE);
+                _this[cashed_size_property] = DEFAULT_SIZE;
+                console.log(_this.read_size_cookie(ulabel.subtasks[subtask]), "inside constructor", subtask, 3);
             }
         }
+        console.log(document.cookie);
+        console.log(ulabel);
         //event listener for buttons
         $(document).on("click", "a.butt-ann", function (e) {
             var button = $(e.currentTarget);
@@ -288,6 +303,10 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
                 case _this.keybind_configuration.annotation_size_plus:
                     _this.update_annotation_size(current_subtask, "inc");
                     break;
+                default:
+                    for (var subtask in ulabel.subtasks) {
+                        console.log(_this[ulabel.subtasks[subtask].display_name.replaceLowerConcat(" ", "-", "-cashed-size")], ulabel.subtasks[subtask].display_name.replaceLowerConcat(" ", "-", "-cashed-size"));
+                    }
             }
             ulabel.redraw_all_annotations(null, null, false);
         });
@@ -301,6 +320,9 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         var increment_size = 0.5;
         var vanish_size = 0.01;
         var subtask_cashed_size = subtask.display_name.replaceLowerConcat(" ", "-", "-cashed-size");
+        if (size == "v") {
+            console.log(this[subtask_cashed_size], subtask);
+        }
         if (subtask == null)
             return;
         var subtask_vanished_flag = subtask.display_name.replaceLowerConcat(" ", "-", "-vanished");
@@ -359,6 +381,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         }
         if (operation == "+") {
             for (var annotation_id in subtask.annotations.access) {
+                console.log(subtask.annotations.access[annotation_id].line_size);
                 subtask.annotations.access[annotation_id].line_size += size;
                 //temporary solution
                 this[subtask_cashed_size] = subtask.annotations.access[annotation_id].line_size;

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -234,6 +234,8 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         _this.inner_HTML = "<p class=\"tb-header\">Annotation Count</p>";
         //get default keybinds
         _this.keybind_configuration = ulabel.config.default_keybinds;
+        //update cased size to default
+        _this.cached_size = ulabel.config.default_annotation_size;
         //grab current subtask for convinience
         var current_subtask_key = ulabel.state["current_subtask"];
         var current_subtask = ulabel.subtasks[current_subtask_key];

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -19,9 +19,11 @@ exports.KeypointSliderItem = exports.RecolorActiveItem = exports.AnnotationResiz
 var __1 = require("..");
 var configuration_1 = require("./configuration");
 var toolboxDividerDiv = "<div class=toolbox-divider></div>";
-function read_annotation_confidence() {
-    return;
-}
+String.prototype.replaceLower = function (before, after) {
+    this.replaceAll(before, after);
+    this.toLowerCase();
+    return this;
+};
 /**
  * Manager for toolbox. Contains ToolboxTab items.
  */
@@ -296,23 +298,23 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
             return;
         //If the annotations are currently vanished and a button other than the vanish button is
         //pressed, then we want to ignore the input
-        if (this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"] && size !== "v")
+        if (this[subtask.display_name.replaceLower(" ", "-") + "-vanished"] && size !== "v")
             return;
         if (typeof (size) === "number") {
             this.loop_through_annotations(subtask, size, "=");
         }
         if (size == "v") {
-            if (this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"]) {
+            if (this[subtask.display_name.replaceLower(" ", "-") + "-vanished"]) {
                 this.loop_through_annotations(subtask, this.cached_size, "=");
                 //flip the bool state
-                this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"] = !this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"];
+                this[subtask.display_name.replaceLower(" ", "-") + "-vanished"] = !this[subtask.display_name.replaceLower(" ", "-") + "-vanished"];
                 $("#annotation-resize-v").attr("style", "background-color: " + "rgba(100, 148, 237, 0.8)");
                 return;
             }
-            if (this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"] !== true) {
+            if (this[subtask.display_name.replaceLower(" ", "-") + "-vanished"] !== true) {
                 this.loop_through_annotations(subtask, vanish_size, "=");
                 //flip the bool state
-                this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"] = !this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"];
+                this[subtask.display_name.replaceLower(" ", "-") + "-vanished"] = !this[subtask.display_name.replaceLower(" ", "-") + "-vanished"];
                 $("#annotation-resize-v").attr("style", "background-color: " + "#1c2d4d");
                 return;
             }
@@ -382,11 +384,11 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
     AnnotationResizeItem.prototype.set_size_cookie = function (cookie_value, subtask) {
         var d = new Date();
         d.setTime(d.getTime() + (10000 * 24 * 60 * 60 * 1000));
-        var subtask_name = subtask.display_name.replaceAll(" ", "_").toLowerCase();
+        var subtask_name = subtask.display_name.replaceLower(" ", "_");
         document.cookie = subtask_name + "_size=" + cookie_value + ";" + d.toUTCString() + ";path=/";
     };
     AnnotationResizeItem.prototype.read_size_cookie = function (subtask) {
-        var subtask_name = subtask.display_name.replaceAll(" ", "_").toLowerCase();
+        var subtask_name = subtask.display_name.replaceLower(" ", "_");
         var cookie_name = subtask_name + "_size=";
         var cookie_array = document.cookie.split(";");
         for (var i = 0; i < cookie_array.length; i++) {
@@ -581,10 +583,10 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         _this.filter_function = kwargs.filter_function;
         _this.get_confidence = kwargs.confidence_function;
         _this.mark_deprecated = kwargs.mark_deprecated;
-        _this.slider_bar_id = _this.name.replaceAll(" ", "-").toLowerCase();
+        _this.slider_bar_id = _this.name.replaceLower(" ", "-");
         //if the config has a default value override, then use that instead
-        if (ulabel.config.hasOwnProperty(_this.name.replaceAll(" ", "_").toLowerCase() + "_default_value")) {
-            kwargs.default_value = ulabel.config[_this.name.split(" ").join("_").toLowerCase() + "_default_value"];
+        if (ulabel.config.hasOwnProperty(_this.name.replaceLower(" ", "_") + "_default_value")) {
+            kwargs.default_value = ulabel.config[_this.name.replaceLower(" ", "_") + "_default_value"];
         }
         //if this keypoint slider has a generic default, then use it
         //otherwise the defalut is 0
@@ -607,13 +609,13 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         }
         //The annotations are drawn for the first time after the toolbox is loaded
         //so we don't actually have to redraw the annotations after deprecating them.
-        $(document).on("input", "#" + _this.name.replaceAll(" ", "-").toLowerCase(), function (e) {
+        $(document).on("input", "#" + _this.name.replaceLower(" ", "-"), function (e) {
             var filter_value = e.currentTarget.value / 100;
             _this.deprecate_annotations(ulabel, filter_value);
         });
-        $(document).on("click", "a." + _this.name.replaceAll(" ", "-").toLowerCase() + "-button", function (e) {
+        $(document).on("click", "a." + _this.name.replaceLower(" ", "-") + "-button", function (e) {
             var button_text = e.currentTarget.outerText;
-            var slider = document.getElementById(_this.name.replaceAll(" ", "-").toLowerCase());
+            var slider = document.getElementById(_this.name.replaceLower(" ", "-"));
             if (button_text == "+") {
                 slider.value = (slider.valueAsNumber + 1).toString();
             }
@@ -631,11 +633,11 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         //event listener for keybinds
         $(document).on("keypress", function (e) {
             if (e.key == kwargs.keybinds.increment) {
-                var button = document.getElementsByClassName(_this.name.replaceAll(" ", "-").toLowerCase() + "-button inc")[0];
+                var button = document.getElementsByClassName(_this.name.replaceLower(" ", "-") + "-button inc")[0];
                 button.click();
             }
             if (e.key == kwargs.keybinds.decrement) {
-                var button = document.getElementsByClassName(_this.name.replaceAll(" ", "-").toLowerCase() + "-button dec")[0];
+                var button = document.getElementsByClassName(_this.name.replaceLower(" ", "-") + "-button dec")[0];
                 button.click();
             }
         });
@@ -685,7 +687,7 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         }
     };
     KeypointSliderItem.prototype.get_html = function () {
-        return "\n        <div class=\"keypoint-slider\">\n            <p class=\"tb-header\">".concat(this.name, "</p>\n            <div class=\"keypoint-slider-holder\">\n                <input \n                    type=\"range\" \n                    id=\"").concat(this.name.replaceAll(" ", "-").toLowerCase(), "\" \n                    class=\"keypoint-slider\" value=\"").concat(this.default_value * 100, "\"\n                />\n                <label \n                    for=\"").concat(this.name.replaceAll(" ", "-").toLowerCase(), "\" \n                    id=\"").concat(this.name.replaceAll(" ", "-").toLowerCase(), "-label\"\n                    class=\"keypoint-slider-label\">\n                    ").concat(Math.round(this.default_value * 100), "%\n                </label>\n                <span class=\"increment\" >\n                    <a href=\"#\" class=\"button inc keypoint-slider-increment ").concat(this.name.replaceAll(" ", "-").toLowerCase(), "-button\" >+</a>\n                    <a href=\"#\" class=\"button dec keypoint-slider-increment ").concat(this.name.replaceAll(" ", "-").toLowerCase(), "-button\" >-</a>\n                </span>\n            </div>\n        </div>");
+        return "\n        <div class=\"keypoint-slider\">\n            <p class=\"tb-header\">".concat(this.name, "</p>\n            <div class=\"keypoint-slider-holder\">\n                <input \n                    type=\"range\" \n                    id=\"").concat(this.name.replaceLower(" ", "-"), "\" \n                    class=\"keypoint-slider\" value=\"").concat(this.default_value * 100, "\"\n                />\n                <label \n                    for=\"").concat(this.name.replaceLower(" ", "-"), "\" \n                    id=\"").concat(this.name.replaceLower(" ", "-"), "-label\"\n                    class=\"keypoint-slider-label\">\n                    ").concat(Math.round(this.default_value * 100), "%\n                </label>\n                <span class=\"increment\" >\n                    <a href=\"#\" class=\"button inc keypoint-slider-increment ").concat(this.name.replaceLower(" ", "-"), "-button\" >+</a>\n                    <a href=\"#\" class=\"button dec keypoint-slider-increment ").concat(this.name.replaceLower(" ", "-"), "-button\" >-</a>\n                </span>\n            </div>\n        </div>");
     };
     return KeypointSliderItem;
 }(ToolboxItem));

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -248,20 +248,20 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         //for a default annotation size. If neither are found it will use the size
         //that the annotation was saved as.
         for (var subtask in ulabel.subtasks) {
-            var cashed_size_property = ulabel.subtasks[subtask].display_name.replaceLowerConcat(" ", "-", "-cashed-size");
+            var cached_size_property = ulabel.subtasks[subtask].display_name.replaceLowerConcat(" ", "-", "-cached-size");
             var size_cookie = _this.read_size_cookie(ulabel.subtasks[subtask]);
             if ((size_cookie != null) && size_cookie != "NaN") {
                 _this.update_annotation_size(ulabel.subtasks[subtask], Number(size_cookie));
-                _this[cashed_size_property] = Number(size_cookie);
+                _this[cached_size_property] = Number(size_cookie);
             }
             else if (ulabel.config.default_annotation_size != undefined) {
                 _this.update_annotation_size(ulabel.subtasks[subtask], ulabel.config.default_annotation_size);
-                _this[cashed_size_property] = ulabel.config.default_annotation_size;
+                _this[cached_size_property] = ulabel.config.default_annotation_size;
             }
             else {
                 var DEFAULT_SIZE = 5;
                 _this.update_annotation_size(ulabel.subtasks[subtask], DEFAULT_SIZE);
-                _this[cashed_size_property] = DEFAULT_SIZE;
+                _this[cached_size_property] = DEFAULT_SIZE;
             }
         }
         //event listener for buttons
@@ -308,7 +308,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         var large_size = 5;
         var increment_size = 0.5;
         var vanish_size = 0.01;
-        var subtask_cashed_size = subtask.display_name.replaceLowerConcat(" ", "-", "-cashed-size");
+        var subtask_cached_size = subtask.display_name.replaceLowerConcat(" ", "-", "-cached-size");
         if (subtask == null)
             return;
         var subtask_vanished_flag = subtask.display_name.replaceLowerConcat(" ", "-", "-vanished");
@@ -321,7 +321,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         }
         if (size == "v") {
             if (this[subtask_vanished_flag]) {
-                this.loop_through_annotations(subtask, this[subtask_cashed_size], "=");
+                this.loop_through_annotations(subtask, this[subtask_cached_size], "=");
                 //flip the bool state
                 this[subtask_vanished_flag] = !this[subtask_vanished_flag];
                 $("#annotation-resize-v").attr("style", "background-color: " + "rgba(100, 148, 237, 0.8)");
@@ -339,11 +339,11 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
         switch (size) {
             case 's':
                 this.loop_through_annotations(subtask, small_size, "=");
-                this[subtask_cashed_size] = small_size;
+                this[subtask_cached_size] = small_size;
                 break;
             case 'l':
                 this.loop_through_annotations(subtask, large_size, "=");
-                this[subtask_cashed_size] = large_size;
+                this[subtask_cached_size] = large_size;
                 break;
             case 'dec':
                 this.loop_through_annotations(subtask, increment_size, "-");
@@ -357,7 +357,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
     };
     //loops through all annotations in a subtask to change their line size
     AnnotationResizeItem.prototype.loop_through_annotations = function (subtask, size, operation) {
-        var subtask_cashed_size = subtask.display_name.replaceLowerConcat(" ", "-", "-cashed-size");
+        var subtask_cached_size = subtask.display_name.replaceLowerConcat(" ", "-", "-cached-size");
         if (operation == "=") {
             for (var annotation_id in subtask.annotations.access) {
                 subtask.annotations.access[annotation_id].line_size = size;
@@ -369,7 +369,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
             for (var annotation_id in subtask.annotations.access) {
                 subtask.annotations.access[annotation_id].line_size += size;
                 //temporary solution
-                this[subtask_cashed_size] = subtask.annotations.access[annotation_id].line_size;
+                this[subtask_cached_size] = subtask.annotations.access[annotation_id].line_size;
             }
             this.set_size_cookie(subtask.annotations.access[subtask.annotations.ordering[0]].line_size, subtask);
             return;
@@ -385,7 +385,7 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
                     subtask.annotations.access[annotation_id].line_size -= size;
                 }
                 //temporary solution
-                this[subtask_cashed_size] = subtask.annotations.access[annotation_id].line_size;
+                this[subtask_cached_size] = subtask.annotations.access[annotation_id].line_size;
             }
             this.set_size_cookie(subtask.annotations.access[subtask.annotations.ordering[0]].line_size, subtask);
             return;

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -19,11 +19,17 @@ exports.KeypointSliderItem = exports.RecolorActiveItem = exports.AnnotationResiz
 var __1 = require("..");
 var configuration_1 = require("./configuration");
 var toolboxDividerDiv = "<div class=toolbox-divider></div>";
-String.prototype.replaceLower = function (before, after) {
+/** Chains the replaceAll method and the toLowerCase method  */
+String.prototype.replaceLowerConcat = function (before, after, concat_string) {
+    if (concat_string === void 0) { concat_string = null; }
     this.replaceAll(before, after);
     this.toLowerCase();
+    if (typeof (concat_string) === "string") {
+        return this.concat(concat_string);
+    }
     return this;
 };
+"this".replaceLowerConcat(" ", "-");
 /**
  * Manager for toolbox. Contains ToolboxTab items.
  */
@@ -298,23 +304,23 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
             return;
         //If the annotations are currently vanished and a button other than the vanish button is
         //pressed, then we want to ignore the input
-        if (this[subtask.display_name.replaceLower(" ", "-") + "-vanished"] && size !== "v")
+        if (this[subtask.display_name.replaceLowerConcat(" ", "-") + "-vanished"] && size !== "v")
             return;
         if (typeof (size) === "number") {
             this.loop_through_annotations(subtask, size, "=");
         }
         if (size == "v") {
-            if (this[subtask.display_name.replaceLower(" ", "-") + "-vanished"]) {
+            if (this[subtask.display_name.replaceLowerConcat(" ", "-") + "-vanished"]) {
                 this.loop_through_annotations(subtask, this.cached_size, "=");
                 //flip the bool state
-                this[subtask.display_name.replaceLower(" ", "-") + "-vanished"] = !this[subtask.display_name.replaceLower(" ", "-") + "-vanished"];
+                this[subtask.display_name.replaceLowerConcat(" ", "-") + "-vanished"] = !this[subtask.display_name.replaceLowerConcat(" ", "-") + "-vanished"];
                 $("#annotation-resize-v").attr("style", "background-color: " + "rgba(100, 148, 237, 0.8)");
                 return;
             }
-            if (this[subtask.display_name.replaceLower(" ", "-") + "-vanished"] !== true) {
+            if (this[subtask.display_name.replaceLowerConcat(" ", "-") + "-vanished"] !== true) {
                 this.loop_through_annotations(subtask, vanish_size, "=");
                 //flip the bool state
-                this[subtask.display_name.replaceLower(" ", "-") + "-vanished"] = !this[subtask.display_name.replaceLower(" ", "-") + "-vanished"];
+                this[subtask.display_name.replaceLowerConcat(" ", "-") + "-vanished"] = !this[subtask.display_name.replaceLowerConcat(" ", "-") + "-vanished"];
                 $("#annotation-resize-v").attr("style", "background-color: " + "#1c2d4d");
                 return;
             }
@@ -384,11 +390,11 @@ var AnnotationResizeItem = /** @class */ (function (_super) {
     AnnotationResizeItem.prototype.set_size_cookie = function (cookie_value, subtask) {
         var d = new Date();
         d.setTime(d.getTime() + (10000 * 24 * 60 * 60 * 1000));
-        var subtask_name = subtask.display_name.replaceLower(" ", "_");
+        var subtask_name = subtask.display_name.replaceLowerConcat(" ", "_");
         document.cookie = subtask_name + "_size=" + cookie_value + ";" + d.toUTCString() + ";path=/";
     };
     AnnotationResizeItem.prototype.read_size_cookie = function (subtask) {
-        var subtask_name = subtask.display_name.replaceLower(" ", "_");
+        var subtask_name = subtask.display_name.replaceLowerConcat(" ", "_");
         var cookie_name = subtask_name + "_size=";
         var cookie_array = document.cookie.split(";");
         for (var i = 0; i < cookie_array.length; i++) {
@@ -583,10 +589,10 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         _this.filter_function = kwargs.filter_function;
         _this.get_confidence = kwargs.confidence_function;
         _this.mark_deprecated = kwargs.mark_deprecated;
-        _this.slider_bar_id = _this.name.replaceLower(" ", "-");
+        _this.slider_bar_id = _this.name.replaceLowerConcat(" ", "-");
         //if the config has a default value override, then use that instead
-        if (ulabel.config.hasOwnProperty(_this.name.replaceLower(" ", "_") + "_default_value")) {
-            kwargs.default_value = ulabel.config[_this.name.replaceLower(" ", "_") + "_default_value"];
+        if (ulabel.config.hasOwnProperty(_this.name.replaceLowerConcat(" ", "_") + "_default_value")) {
+            kwargs.default_value = ulabel.config[_this.name.replaceLowerConcat(" ", "_") + "_default_value"];
         }
         //if this keypoint slider has a generic default, then use it
         //otherwise the defalut is 0
@@ -609,13 +615,13 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         }
         //The annotations are drawn for the first time after the toolbox is loaded
         //so we don't actually have to redraw the annotations after deprecating them.
-        $(document).on("input", "#" + _this.name.replaceLower(" ", "-"), function (e) {
+        $(document).on("input", "#" + _this.name.replaceLowerConcat(" ", "-"), function (e) {
             var filter_value = e.currentTarget.value / 100;
             _this.deprecate_annotations(ulabel, filter_value);
         });
-        $(document).on("click", "a." + _this.name.replaceLower(" ", "-") + "-button", function (e) {
+        $(document).on("click", "a." + _this.name.replaceLowerConcat(" ", "-") + "-button", function (e) {
             var button_text = e.currentTarget.outerText;
-            var slider = document.getElementById(_this.name.replaceLower(" ", "-"));
+            var slider = document.getElementById(_this.name.replaceLowerConcat(" ", "-"));
             if (button_text == "+") {
                 slider.value = (slider.valueAsNumber + 1).toString();
             }
@@ -633,11 +639,11 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         //event listener for keybinds
         $(document).on("keypress", function (e) {
             if (e.key == kwargs.keybinds.increment) {
-                var button = document.getElementsByClassName(_this.name.replaceLower(" ", "-") + "-button inc")[0];
+                var button = document.getElementsByClassName(_this.name.replaceLowerConcat(" ", "-") + "-button inc")[0];
                 button.click();
             }
             if (e.key == kwargs.keybinds.decrement) {
-                var button = document.getElementsByClassName(_this.name.replaceLower(" ", "-") + "-button dec")[0];
+                var button = document.getElementsByClassName(_this.name.replaceLowerConcat(" ", "-") + "-button dec")[0];
                 button.click();
             }
         });
@@ -687,7 +693,7 @@ var KeypointSliderItem = /** @class */ (function (_super) {
         }
     };
     KeypointSliderItem.prototype.get_html = function () {
-        return "\n        <div class=\"keypoint-slider\">\n            <p class=\"tb-header\">".concat(this.name, "</p>\n            <div class=\"keypoint-slider-holder\">\n                <input \n                    type=\"range\" \n                    id=\"").concat(this.name.replaceLower(" ", "-"), "\" \n                    class=\"keypoint-slider\" value=\"").concat(this.default_value * 100, "\"\n                />\n                <label \n                    for=\"").concat(this.name.replaceLower(" ", "-"), "\" \n                    id=\"").concat(this.name.replaceLower(" ", "-"), "-label\"\n                    class=\"keypoint-slider-label\">\n                    ").concat(Math.round(this.default_value * 100), "%\n                </label>\n                <span class=\"increment\" >\n                    <a href=\"#\" class=\"button inc keypoint-slider-increment ").concat(this.name.replaceLower(" ", "-"), "-button\" >+</a>\n                    <a href=\"#\" class=\"button dec keypoint-slider-increment ").concat(this.name.replaceLower(" ", "-"), "-button\" >-</a>\n                </span>\n            </div>\n        </div>");
+        return "\n        <div class=\"keypoint-slider\">\n            <p class=\"tb-header\">".concat(this.name, "</p>\n            <div class=\"keypoint-slider-holder\">\n                <input \n                    type=\"range\" \n                    id=\"").concat(this.name.replaceLowerConcat(" ", "-"), "\" \n                    class=\"keypoint-slider\" value=\"").concat(this.default_value * 100, "\"\n                />\n                <label \n                    for=\"").concat(this.name.replaceLowerConcat(" ", "-"), "\" \n                    id=\"").concat(this.name.replaceLowerConcat(" ", "-"), "-label\"\n                    class=\"keypoint-slider-label\">\n                    ").concat(Math.round(this.default_value * 100), "%\n                </label>\n                <span class=\"increment\" >\n                    <a href=\"#\" class=\"button inc keypoint-slider-increment ").concat(this.name.replaceLowerConcat(" ", "-"), "-button\" >+</a>\n                    <a href=\"#\" class=\"button dec keypoint-slider-increment ").concat(this.name.replaceLowerConcat(" ", "-"), "-button\" >-</a>\n                </span>\n            </div>\n        </div>");
     };
     return KeypointSliderItem;
 }(ToolboxItem));

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -315,7 +315,6 @@ export class ClassCounterToolboxItem extends ToolboxItem {
  * Toolbox item for resizing all annotations
  */
 export class AnnotationResizeItem extends ToolboxItem {
-    public is_vanished: boolean = false;
     public cached_size: number = 1.5;
     public html: string;
     public inner_HTML: string;
@@ -393,24 +392,24 @@ export class AnnotationResizeItem extends ToolboxItem {
 
         //If the annotations are currently vanished and a button other than the vanish button is
         //pressed, then we want to ignore the input
-        if (this.is_vanished && size !== "v") return;
+        if (this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"] && size !== "v") return;
 
         if (typeof(size) === "number") {
             this.loop_through_annotations(subtask, size, "=");
         }
 
         if (size == "v") {
-            if (this.is_vanished) { 
+            if (this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"]) { 
                 this.loop_through_annotations(subtask, this.cached_size, "=")
                 //flip the bool state
-                this.is_vanished = !this.is_vanished
+                this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"] = !this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"]
                 $("#annotation-resize-v").attr("style","background-color: "+"rgba(100, 148, 237, 0.8)");
                 return;
             }
-            if (this.is_vanished !== true) {
+            if (this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"] !== true) {
                 this.loop_through_annotations(subtask, vanish_size, "=")
                 //flip the bool state
-                this.is_vanished = !this.is_vanished;
+                this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"] = !this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"]
                 $("#annotation-resize-v").attr("style","background-color: "+"#1c2d4d");
                 return;
             }

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -336,7 +336,6 @@ export class AnnotationResizeItem extends ToolboxItem {
         //First check for a size cookie, if one isn't found then check the config
         //for a default annotation size. If neither are found it will use the size
         //that the annotation was saved as.
-        console.log(this.read_size_cookie(current_subtask))
         if (this.read_size_cookie(current_subtask) != null) {           
             this.update_annotation_size(current_subtask, Number(this.read_size_cookie(current_subtask)));
         } 

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -326,6 +326,9 @@ export class AnnotationResizeItem extends ToolboxItem {
         //get default keybinds
         this.keybind_configuration = ulabel.config.default_keybinds
 
+        //update cased size to default
+        this.cached_size = ulabel.config.default_annotation_size
+
         //grab current subtask for convinience
         let current_subtask_key = ulabel.state["current_subtask"];
         let current_subtask = ulabel.subtasks[current_subtask_key];

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -356,7 +356,6 @@ export class AnnotationResizeItem extends ToolboxItem {
         $(document).on("keypress", (e) => {
             var current_subtask_key = ulabel.state["current_subtask"];
             var current_subtask = ulabel.subtasks[current_subtask_key];
-            console.log(e.key)
             switch(e.key) {
                 case this.keybind_configuration.annotation_vanish.toUpperCase():
                     this.update_all_subtask_annotation_size(ulabel, "v");
@@ -473,10 +472,9 @@ export class AnnotationResizeItem extends ToolboxItem {
         throw Error("Invalid Operation given to loop_through_annotations")
     }
 
+    //Loop through all subtasks and apply a size to them all
     public update_all_subtask_annotation_size(ulabel, size) {
-        console.log(ulabel)
         for (let subtask in ulabel.subtasks) {
-            console.log(subtask)
             this.update_annotation_size(ulabel.subtasks[subtask], size)
         }
     }

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -3,9 +3,12 @@ import { Configuration } from "./configuration";
 import { ULabelAnnotation } from "./annotation";
 
 const toolboxDividerDiv = "<div class=toolbox-divider></div>"
-function read_annotation_confidence() {
-    return
+String.prototype.replaceLower = function(before: string, after: string) {
+    this.replaceAll(before, after)
+    this.toLowerCase()
+    return this
 }
+
 
 /**
  * Manager for toolbox. Contains ToolboxTab items.
@@ -393,24 +396,24 @@ export class AnnotationResizeItem extends ToolboxItem {
 
         //If the annotations are currently vanished and a button other than the vanish button is
         //pressed, then we want to ignore the input
-        if (this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"] && size !== "v") return;
+        if (this[subtask.display_name.replaceLower(" ", "-") + "-vanished"] && size !== "v") return;
 
         if (typeof(size) === "number") {
             this.loop_through_annotations(subtask, size, "=");
         }
 
         if (size == "v") {
-            if (this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"]) { 
+            if (this[subtask.display_name.replaceLower(" ", "-") + "-vanished"]) { 
                 this.loop_through_annotations(subtask, this.cached_size, "=")
                 //flip the bool state
-                this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"] = !this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"]
+                this[subtask.display_name.replaceLower(" ", "-") + "-vanished"] = !this[subtask.display_name.replaceLower(" ", "-") + "-vanished"]
                 $("#annotation-resize-v").attr("style","background-color: "+"rgba(100, 148, 237, 0.8)");
                 return;
             }
-            if (this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"] !== true) {
+            if (this[subtask.display_name.replaceLower(" ", "-") + "-vanished"] !== true) {
                 this.loop_through_annotations(subtask, vanish_size, "=")
                 //flip the bool state
-                this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"] = !this[subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished"]
+                this[subtask.display_name.replaceLower(" ", "-") + "-vanished"] = !this[subtask.display_name.replaceLower(" ", "-") + "-vanished"]
                 $("#annotation-resize-v").attr("style","background-color: "+"#1c2d4d");
                 return;
             }
@@ -483,14 +486,14 @@ export class AnnotationResizeItem extends ToolboxItem {
         let d = new Date();
         d.setTime(d.getTime() + (10000 * 24 * 60 * 60 * 1000));
 
-        let subtask_name = subtask.display_name.replaceAll(" ","_").toLowerCase();
+        let subtask_name = subtask.display_name.replaceLower(" ", "_");
 
         document.cookie = subtask_name + "_size=" + cookie_value + ";" + d.toUTCString() + ";path=/";
     }
 
     private read_size_cookie(subtask) {
 
-        let subtask_name = subtask.display_name.replaceAll(" ","_").toLowerCase();
+        let subtask_name = subtask.display_name.replaceLower(" ", "_");
 
         let cookie_name = subtask_name + "_size=";       
 
@@ -780,11 +783,11 @@ export class KeypointSliderItem extends ToolboxItem {
         this.filter_function = kwargs.filter_function;
         this.get_confidence = kwargs.confidence_function;
         this.mark_deprecated = kwargs.mark_deprecated;
-        this.slider_bar_id = this.name.replaceAll(" ", "-").toLowerCase();
+        this.slider_bar_id = this.name.replaceLower(" ", "-");
         
         //if the config has a default value override, then use that instead
-        if (ulabel.config.hasOwnProperty(this.name.replaceAll(" ","_").toLowerCase() + "_default_value")) {
-            kwargs.default_value = ulabel.config[this.name.split(" ").join("_").toLowerCase() + "_default_value"];
+        if (ulabel.config.hasOwnProperty(this.name.replaceLower(" ", "_") + "_default_value")) {
+            kwargs.default_value = ulabel.config[this.name.replaceLower(" ", "_") + "_default_value"];
         }
 
         //if this keypoint slider has a generic default, then use it
@@ -814,14 +817,14 @@ export class KeypointSliderItem extends ToolboxItem {
         //The annotations are drawn for the first time after the toolbox is loaded
         //so we don't actually have to redraw the annotations after deprecating them.
         
-        $(document).on("input", "#" + this.name.replaceAll(" ", "-").toLowerCase(), (e) => {
+        $(document).on("input", "#" + this.name.replaceLower(" ", "-"), (e) => {
             let filter_value = e.currentTarget.value / 100;
             this.deprecate_annotations(ulabel, filter_value);
         })
 
-        $(document).on("click", "a." + this.name.replaceAll(" ", "-").toLowerCase() + "-button", (e) => {
+        $(document).on("click", "a." + this.name.replaceLower(" ", "-") + "-button", (e) => {
             let button_text = e.currentTarget.outerText
-            let slider = <HTMLInputElement> document.getElementById(this.name.replaceAll(" ", "-").toLowerCase())
+            let slider = <HTMLInputElement> document.getElementById(this.name.replaceLower(" ", "-"))
 
             if (button_text == "+") {
                 slider.value = (slider.valueAsNumber + 1).toString();
@@ -842,12 +845,12 @@ export class KeypointSliderItem extends ToolboxItem {
         $(document).on("keypress", (e) => {
 
             if (e.key == kwargs.keybinds.increment) {
-                let button = <HTMLAnchorElement> document.getElementsByClassName(this.name.replaceAll(" ", "-").toLowerCase() + "-button inc")[0]
+                let button = <HTMLAnchorElement> document.getElementsByClassName(this.name.replaceLower(" ", "-") + "-button inc")[0]
                 button.click()
             }
 
             if (e.key == kwargs.keybinds.decrement) {
-                let button = <HTMLAnchorElement> document.getElementsByClassName(this.name.replaceAll(" ", "-").toLowerCase() + "-button dec")[0]
+                let button = <HTMLAnchorElement> document.getElementsByClassName(this.name.replaceLower(" ", "-") + "-button dec")[0]
                 button.click()
             }
         })
@@ -916,18 +919,18 @@ export class KeypointSliderItem extends ToolboxItem {
             <div class="keypoint-slider-holder">
                 <input 
                     type="range" 
-                    id="${this.name.replaceAll(" ", "-").toLowerCase()}" 
+                    id="${this.name.replaceLower(" ", "-")}" 
                     class="keypoint-slider" value="${this.default_value * 100}"
                 />
                 <label 
-                    for="${this.name.replaceAll(" ", "-").toLowerCase()}" 
-                    id="${this.name.replaceAll(" ", "-").toLowerCase()}-label"
+                    for="${this.name.replaceLower(" ", "-")}" 
+                    id="${this.name.replaceLower(" ", "-")}-label"
                     class="keypoint-slider-label">
                     ${Math.round(this.default_value * 100)}%
                 </label>
                 <span class="increment" >
-                    <a href="#" class="button inc keypoint-slider-increment ${this.name.replaceAll(" ", "-").toLowerCase()}-button" >+</a>
-                    <a href="#" class="button dec keypoint-slider-increment ${this.name.replaceAll(" ", "-").toLowerCase()}-button" >-</a>
+                    <a href="#" class="button inc keypoint-slider-increment ${this.name.replaceLower(" ", "-")}-button" >+</a>
+                    <a href="#" class="button dec keypoint-slider-increment ${this.name.replaceLower(" ", "-")}-button" >-</a>
                 </span>
             </div>
         </div>`

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -357,6 +357,9 @@ export class AnnotationResizeItem extends ToolboxItem {
             var current_subtask = ulabel.subtasks[current_subtask_key];
             console.log(e.key)
             switch(e.key) {
+                case this.keybind_configuration.annotation_vanish.toUpperCase():
+                    this.update_all_subtask_annotation_size(ulabel, "v");
+                    break;
                 case this.keybind_configuration.annotation_vanish:
                     this.update_annotation_size(current_subtask, "v")
                     break;
@@ -467,6 +470,14 @@ export class AnnotationResizeItem extends ToolboxItem {
             return;
         }
         throw Error("Invalid Operation given to loop_through_annotations")
+    }
+
+    public update_all_subtask_annotation_size(ulabel, size) {
+        console.log(ulabel)
+        for (let subtask in ulabel.subtasks) {
+            console.log(subtask)
+            this.update_annotation_size(ulabel.subtasks[subtask], size)
+        }
     }
 
     private set_size_cookie(cookie_value, subtask) {

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -4,15 +4,16 @@ import { ULabelAnnotation } from "./annotation";
 
 const toolboxDividerDiv = "<div class=toolbox-divider></div>"
 
-/** Chains the replaceAll method and the toLowerCase method  */
+/** Chains the replaceAll method and the toLowerCase method.
+ *  Optionally concatenates a string at the end of the method.
+  */
 String.prototype.replaceLowerConcat = function(before: string, after: string, concat_string: string = null) {
-    this.replaceAll(before, after)
-    this.toLowerCase()
     
     if (typeof(concat_string) === "string") {
-        return this.concat(concat_string)
+        return this.replaceAll(before, after).toLowerCase().concat(concat_string)
     }
-    return this
+
+    return this.replaceAll(before, after).toLowerCase()
 }
 
 
@@ -399,7 +400,7 @@ export class AnnotationResizeItem extends ToolboxItem {
         const vanish_size = 0.01;
 
         if (subtask == null) return;
-let subtask_vanished_flag = subtask.display_name.replaceAll(" ", "-").toLowerCase() + "-vanished";
+        let subtask_vanished_flag = subtask.display_name.replaceLowerConcat(" ", "-", "-vanished");
         //If the annotations are currently vanished and a button other than the vanish button is
         //pressed, then we want to ignore the input
         if (this[subtask_vanished_flag] && size !== "v") return;
@@ -919,24 +920,25 @@ export class KeypointSliderItem extends ToolboxItem {
     }
 
     public get_html() {
+        let component_name = this.name.replaceLowerConcat(" ", "-")
         return`
         <div class="keypoint-slider">
             <p class="tb-header">${this.name}</p>
             <div class="keypoint-slider-holder">
                 <input 
                     type="range" 
-                    id="${this.name.replaceLowerConcat(" ", "-")}" 
+                    id="${component_name}" 
                     class="keypoint-slider" value="${this.default_value * 100}"
                 />
                 <label 
-                    for="${this.name.replaceLowerConcat(" ", "-")}" 
-                    id="${this.name.replaceLowerConcat(" ", "-")}-label"
+                    for="${component_name}" 
+                    id="${component_name}-label"
                     class="keypoint-slider-label">
                     ${Math.round(this.default_value * 100)}%
                 </label>
                 <span class="increment" >
-                    <a href="#" class="button inc keypoint-slider-increment ${this.name.replaceLowerConcat(" ", "-")}-button" >+</a>
-                    <a href="#" class="button dec keypoint-slider-increment ${this.name.replaceLowerConcat(" ", "-")}-button" >-</a>
+                    <a href="#" class="button inc keypoint-slider-increment ${component_name}-button" >+</a>
+                    <a href="#" class="button dec keypoint-slider-increment ${component_name}-button" >-</a>
                 </span>
             </div>
         </div>`

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -332,7 +332,6 @@ export class AnnotationResizeItem extends ToolboxItem {
     constructor(ulabel: ULabel) {
         super();
         this.inner_HTML = `<p class="tb-header">Annotation Count</p>`;
-        console.log(document.cookie)
         //get default keybinds
         this.keybind_configuration = ulabel.config.default_keybinds
 
@@ -347,26 +346,19 @@ export class AnnotationResizeItem extends ToolboxItem {
             let cashed_size_property = ulabel.subtasks[subtask].display_name.replaceLowerConcat(" ", "-", "-cashed-size")
             let size_cookie = this.read_size_cookie(ulabel.subtasks[subtask])
             if ((size_cookie != null) && size_cookie != "NaN") {
-                console.log(size_cookie, size_cookie != "NaN")
                 this.update_annotation_size(ulabel.subtasks[subtask], Number(size_cookie));
-                console.log(size_cookie, "inside constructor", subtask)
                 this[cashed_size_property] = Number(size_cookie)
             }
             else if (ulabel.config.default_annotation_size != undefined) {          
                 this.update_annotation_size(ulabel.subtasks[subtask], ulabel.config.default_annotation_size);
                 this[cashed_size_property] = ulabel.config.default_annotation_size
-                console.log(this.read_size_cookie(ulabel.subtasks[subtask]), "inside constructor", subtask, 2)
             } 
             else {
                 const DEFAULT_SIZE = 5
                 this.update_annotation_size(ulabel.subtasks[subtask], DEFAULT_SIZE)
                 this[cashed_size_property] = DEFAULT_SIZE
-                console.log(this.read_size_cookie(ulabel.subtasks[subtask]), "inside constructor", subtask, 3)
             }
         }
-
-        console.log(document.cookie)
-        console.log(ulabel)
 
         //event listener for buttons
         $(document).on("click", "a.butt-ann", (e) => {
@@ -400,10 +392,6 @@ export class AnnotationResizeItem extends ToolboxItem {
                 case this.keybind_configuration.annotation_size_plus:
                     this.update_annotation_size(current_subtask, "inc")
                     break;
-                default:
-                    for (let subtask in ulabel.subtasks) {
-                        console.log(this[ulabel.subtasks[subtask].display_name.replaceLowerConcat(" ", "-", "-cashed-size")], ulabel.subtasks[subtask].display_name.replaceLowerConcat(" ", "-", "-cashed-size"))
-                    }
             }
             ulabel.redraw_all_annotations(null, null, false);
         } )
@@ -418,10 +406,6 @@ export class AnnotationResizeItem extends ToolboxItem {
         const increment_size = 0.5;
         const vanish_size = 0.01;
         let subtask_cashed_size = subtask.display_name.replaceLowerConcat(" ", "-", "-cashed-size");
-
-        if (size == "v") {
-            console.log(this[subtask_cashed_size], subtask)
-        }
 
         if (subtask == null) return;
         let subtask_vanished_flag = subtask.display_name.replaceLowerConcat(" ", "-", "-vanished");
@@ -482,7 +466,6 @@ export class AnnotationResizeItem extends ToolboxItem {
         }
         if (operation == "+") {
             for (const annotation_id in subtask.annotations.access) {
-                console.log(subtask.annotations.access[annotation_id].line_size)
                 subtask.annotations.access[annotation_id].line_size += size;
                 //temporary solution
                 this[subtask_cashed_size] = subtask.annotations.access[annotation_id].line_size
@@ -525,7 +508,6 @@ export class AnnotationResizeItem extends ToolboxItem {
     }
 
     private read_size_cookie(subtask) {
-        console.log(subtask, "Read Size Cookie")
         let subtask_name = subtask.display_name.replaceLowerConcat(" ", "_");
 
         let cookie_name = subtask_name + "_size=";       

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -344,13 +344,29 @@ export class AnnotationResizeItem extends ToolboxItem {
         //for a default annotation size. If neither are found it will use the size
         //that the annotation was saved as.
         for (let subtask in ulabel.subtasks) {
-            if (this.read_size_cookie(ulabel.subtasks[subtask]) != null) {
-                this.update_annotation_size(ulabel.subtasks[subtask], Number(this.read_size_cookie(ulabel.subtasks[subtask])));
+            let cashed_size_property = ulabel.subtasks[subtask].display_name.replaceLowerConcat(" ", "-", "-cashed-size")
+            let size_cookie = this.read_size_cookie(ulabel.subtasks[subtask])
+            if ((size_cookie != null) && size_cookie != "NaN") {
+                console.log(size_cookie, size_cookie != "NaN")
+                this.update_annotation_size(ulabel.subtasks[subtask], Number(size_cookie));
+                console.log(size_cookie, "inside constructor", subtask)
+                this[cashed_size_property] = Number(size_cookie)
             }
             else if (ulabel.config.default_annotation_size != undefined) {          
                 this.update_annotation_size(ulabel.subtasks[subtask], ulabel.config.default_annotation_size);
+                this[cashed_size_property] = ulabel.config.default_annotation_size
+                console.log(this.read_size_cookie(ulabel.subtasks[subtask]), "inside constructor", subtask, 2)
+            } 
+            else {
+                const DEFAULT_SIZE = 5
+                this.update_annotation_size(ulabel.subtasks[subtask], DEFAULT_SIZE)
+                this[cashed_size_property] = DEFAULT_SIZE
+                console.log(this.read_size_cookie(ulabel.subtasks[subtask]), "inside constructor", subtask, 3)
             }
         }
+
+        console.log(document.cookie)
+        console.log(ulabel)
 
         //event listener for buttons
         $(document).on("click", "a.butt-ann", (e) => {
@@ -384,6 +400,10 @@ export class AnnotationResizeItem extends ToolboxItem {
                 case this.keybind_configuration.annotation_size_plus:
                     this.update_annotation_size(current_subtask, "inc")
                     break;
+                default:
+                    for (let subtask in ulabel.subtasks) {
+                        console.log(this[ulabel.subtasks[subtask].display_name.replaceLowerConcat(" ", "-", "-cashed-size")], ulabel.subtasks[subtask].display_name.replaceLowerConcat(" ", "-", "-cashed-size"))
+                    }
             }
             ulabel.redraw_all_annotations(null, null, false);
         } )
@@ -398,6 +418,10 @@ export class AnnotationResizeItem extends ToolboxItem {
         const increment_size = 0.5;
         const vanish_size = 0.01;
         let subtask_cashed_size = subtask.display_name.replaceLowerConcat(" ", "-", "-cashed-size");
+
+        if (size == "v") {
+            console.log(this[subtask_cashed_size], subtask)
+        }
 
         if (subtask == null) return;
         let subtask_vanished_flag = subtask.display_name.replaceLowerConcat(" ", "-", "-vanished");
@@ -458,6 +482,7 @@ export class AnnotationResizeItem extends ToolboxItem {
         }
         if (operation == "+") {
             for (const annotation_id in subtask.annotations.access) {
+                console.log(subtask.annotations.access[annotation_id].line_size)
                 subtask.annotations.access[annotation_id].line_size += size;
                 //temporary solution
                 this[subtask_cashed_size] = subtask.annotations.access[annotation_id].line_size

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -3,9 +3,15 @@ import { Configuration } from "./configuration";
 import { ULabelAnnotation } from "./annotation";
 
 const toolboxDividerDiv = "<div class=toolbox-divider></div>"
-String.prototype.replaceLower = function(before: string, after: string) {
+
+/** Chains the replaceAll method and the toLowerCase method  */
+String.prototype.replaceLowerConcat = function(before: string, after: string, concat_string: string = null) {
     this.replaceAll(before, after)
     this.toLowerCase()
+    
+    if (typeof(concat_string) === "string") {
+        return this.concat(concat_string)
+    }
     return this
 }
 
@@ -396,24 +402,24 @@ export class AnnotationResizeItem extends ToolboxItem {
 
         //If the annotations are currently vanished and a button other than the vanish button is
         //pressed, then we want to ignore the input
-        if (this[subtask.display_name.replaceLower(" ", "-") + "-vanished"] && size !== "v") return;
+        if (this[subtask.display_name.replaceLowerConcat(" ", "-", "-vanished")] && size !== "v") return;
 
         if (typeof(size) === "number") {
             this.loop_through_annotations(subtask, size, "=");
         }
 
         if (size == "v") {
-            if (this[subtask.display_name.replaceLower(" ", "-") + "-vanished"]) { 
+            if (this[subtask.display_name.replaceLowerConcat(" ", "-", "-vanished")]) { 
                 this.loop_through_annotations(subtask, this.cached_size, "=")
                 //flip the bool state
-                this[subtask.display_name.replaceLower(" ", "-") + "-vanished"] = !this[subtask.display_name.replaceLower(" ", "-") + "-vanished"]
+                this[subtask.display_name.replaceLowerConcat(" ", "-", "-vanished")] = !this[subtask.display_name.replaceLowerConcat(" ", "-", "-vanished")]
                 $("#annotation-resize-v").attr("style","background-color: "+"rgba(100, 148, 237, 0.8)");
                 return;
             }
-            if (this[subtask.display_name.replaceLower(" ", "-") + "-vanished"] !== true) {
+            if (this[subtask.display_name.replaceLowerConcat(" ", "-", "-vanished")] !== true) {
                 this.loop_through_annotations(subtask, vanish_size, "=")
                 //flip the bool state
-                this[subtask.display_name.replaceLower(" ", "-") + "-vanished"] = !this[subtask.display_name.replaceLower(" ", "-") + "-vanished"]
+                this[subtask.display_name.replaceLowerConcat(" ", "-", "-vanished")] = !this[subtask.display_name.replaceLowerConcat(" ", "-", "-vanished")]
                 $("#annotation-resize-v").attr("style","background-color: "+"#1c2d4d");
                 return;
             }
@@ -486,14 +492,14 @@ export class AnnotationResizeItem extends ToolboxItem {
         let d = new Date();
         d.setTime(d.getTime() + (10000 * 24 * 60 * 60 * 1000));
 
-        let subtask_name = subtask.display_name.replaceLower(" ", "_");
+        let subtask_name = subtask.display_name.replaceLowerConcat(" ", "_");
 
         document.cookie = subtask_name + "_size=" + cookie_value + ";" + d.toUTCString() + ";path=/";
     }
 
     private read_size_cookie(subtask) {
 
-        let subtask_name = subtask.display_name.replaceLower(" ", "_");
+        let subtask_name = subtask.display_name.replaceLowerConcat(" ", "_");
 
         let cookie_name = subtask_name + "_size=";       
 
@@ -783,11 +789,11 @@ export class KeypointSliderItem extends ToolboxItem {
         this.filter_function = kwargs.filter_function;
         this.get_confidence = kwargs.confidence_function;
         this.mark_deprecated = kwargs.mark_deprecated;
-        this.slider_bar_id = this.name.replaceLower(" ", "-");
+        this.slider_bar_id = this.name.replaceLowerConcat(" ", "-");
         
         //if the config has a default value override, then use that instead
-        if (ulabel.config.hasOwnProperty(this.name.replaceLower(" ", "_") + "_default_value")) {
-            kwargs.default_value = ulabel.config[this.name.replaceLower(" ", "_") + "_default_value"];
+        if (ulabel.config.hasOwnProperty(this.name.replaceLowerConcat(" ", "_", "_default_value"))) {
+            kwargs.default_value = ulabel.config[this.name.replaceLowerConcat(" ", "_", "_default_value")];
         }
 
         //if this keypoint slider has a generic default, then use it
@@ -817,14 +823,14 @@ export class KeypointSliderItem extends ToolboxItem {
         //The annotations are drawn for the first time after the toolbox is loaded
         //so we don't actually have to redraw the annotations after deprecating them.
         
-        $(document).on("input", "#" + this.name.replaceLower(" ", "-"), (e) => {
+        $(document).on("input", "#" + this.name.replaceLowerConcat(" ", "-"), (e) => {
             let filter_value = e.currentTarget.value / 100;
             this.deprecate_annotations(ulabel, filter_value);
         })
 
-        $(document).on("click", "a." + this.name.replaceLower(" ", "-") + "-button", (e) => {
+        $(document).on("click", "a." + this.name.replaceLowerConcat(" ", "-") + "-button", (e) => {
             let button_text = e.currentTarget.outerText
-            let slider = <HTMLInputElement> document.getElementById(this.name.replaceLower(" ", "-"))
+            let slider = <HTMLInputElement> document.getElementById(this.name.replaceLowerConcat(" ", "-"))
 
             if (button_text == "+") {
                 slider.value = (slider.valueAsNumber + 1).toString();
@@ -845,12 +851,12 @@ export class KeypointSliderItem extends ToolboxItem {
         $(document).on("keypress", (e) => {
 
             if (e.key == kwargs.keybinds.increment) {
-                let button = <HTMLAnchorElement> document.getElementsByClassName(this.name.replaceLower(" ", "-") + "-button inc")[0]
+                let button = <HTMLAnchorElement> document.getElementsByClassName(this.name.replaceLowerConcat(" ", "-") + "-button inc")[0]
                 button.click()
             }
 
             if (e.key == kwargs.keybinds.decrement) {
-                let button = <HTMLAnchorElement> document.getElementsByClassName(this.name.replaceLower(" ", "-") + "-button dec")[0]
+                let button = <HTMLAnchorElement> document.getElementsByClassName(this.name.replaceLowerConcat(" ", "-") + "-button dec")[0]
                 button.click()
             }
         })
@@ -919,18 +925,18 @@ export class KeypointSliderItem extends ToolboxItem {
             <div class="keypoint-slider-holder">
                 <input 
                     type="range" 
-                    id="${this.name.replaceLower(" ", "-")}" 
+                    id="${this.name.replaceLowerConcat(" ", "-")}" 
                     class="keypoint-slider" value="${this.default_value * 100}"
                 />
                 <label 
-                    for="${this.name.replaceLower(" ", "-")}" 
-                    id="${this.name.replaceLower(" ", "-")}-label"
+                    for="${this.name.replaceLowerConcat(" ", "-")}" 
+                    id="${this.name.replaceLowerConcat(" ", "-")}-label"
                     class="keypoint-slider-label">
                     ${Math.round(this.default_value * 100)}%
                 </label>
                 <span class="increment" >
-                    <a href="#" class="button inc keypoint-slider-increment ${this.name.replaceLower(" ", "-")}-button" >+</a>
-                    <a href="#" class="button dec keypoint-slider-increment ${this.name.replaceLower(" ", "-")}-button" >-</a>
+                    <a href="#" class="button inc keypoint-slider-increment ${this.name.replaceLowerConcat(" ", "-")}-button" >+</a>
+                    <a href="#" class="button dec keypoint-slider-increment ${this.name.replaceLowerConcat(" ", "-")}-button" >-</a>
                 </span>
             </div>
         </div>`

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -343,20 +343,20 @@ export class AnnotationResizeItem extends ToolboxItem {
         //for a default annotation size. If neither are found it will use the size
         //that the annotation was saved as.
         for (let subtask in ulabel.subtasks) {
-            let cashed_size_property = ulabel.subtasks[subtask].display_name.replaceLowerConcat(" ", "-", "-cashed-size")
+            let cached_size_property = ulabel.subtasks[subtask].display_name.replaceLowerConcat(" ", "-", "-cached-size")
             let size_cookie = this.read_size_cookie(ulabel.subtasks[subtask])
             if ((size_cookie != null) && size_cookie != "NaN") {
                 this.update_annotation_size(ulabel.subtasks[subtask], Number(size_cookie));
-                this[cashed_size_property] = Number(size_cookie)
+                this[cached_size_property] = Number(size_cookie)
             }
             else if (ulabel.config.default_annotation_size != undefined) {          
                 this.update_annotation_size(ulabel.subtasks[subtask], ulabel.config.default_annotation_size);
-                this[cashed_size_property] = ulabel.config.default_annotation_size
+                this[cached_size_property] = ulabel.config.default_annotation_size
             } 
             else {
                 const DEFAULT_SIZE = 5
                 this.update_annotation_size(ulabel.subtasks[subtask], DEFAULT_SIZE)
-                this[cashed_size_property] = DEFAULT_SIZE
+                this[cached_size_property] = DEFAULT_SIZE
             }
         }
 
@@ -405,7 +405,7 @@ export class AnnotationResizeItem extends ToolboxItem {
         const large_size = 5;
         const increment_size = 0.5;
         const vanish_size = 0.01;
-        let subtask_cashed_size = subtask.display_name.replaceLowerConcat(" ", "-", "-cashed-size");
+        let subtask_cached_size = subtask.display_name.replaceLowerConcat(" ", "-", "-cached-size");
 
         if (subtask == null) return;
         let subtask_vanished_flag = subtask.display_name.replaceLowerConcat(" ", "-", "-vanished");
@@ -419,7 +419,7 @@ export class AnnotationResizeItem extends ToolboxItem {
 
         if (size == "v") {
             if (this[subtask_vanished_flag]) { 
-                this.loop_through_annotations(subtask, this[subtask_cashed_size], "=")
+                this.loop_through_annotations(subtask, this[subtask_cached_size], "=")
                 //flip the bool state
                 this[subtask_vanished_flag] = !this[subtask_vanished_flag]
                 $("#annotation-resize-v").attr("style","background-color: "+"rgba(100, 148, 237, 0.8)");
@@ -438,11 +438,11 @@ export class AnnotationResizeItem extends ToolboxItem {
         switch(size) {
             case 's':
                 this.loop_through_annotations(subtask, small_size, "=")
-                this[subtask_cashed_size] = small_size
+                this[subtask_cached_size] = small_size
                 break;           
             case 'l':
                 this.loop_through_annotations(subtask, large_size, "=")
-                this[subtask_cashed_size] = large_size
+                this[subtask_cached_size] = large_size
                 break;
             case 'dec':
                 this.loop_through_annotations(subtask, increment_size, "-")
@@ -456,7 +456,7 @@ export class AnnotationResizeItem extends ToolboxItem {
     }
     //loops through all annotations in a subtask to change their line size
     public loop_through_annotations(subtask, size, operation) {
-        let subtask_cashed_size = subtask.display_name.replaceLowerConcat(" ", "-", "-cashed-size");
+        let subtask_cached_size = subtask.display_name.replaceLowerConcat(" ", "-", "-cached-size");
         if (operation == "=") {
             for (const annotation_id in subtask.annotations.access) {
                 subtask.annotations.access[annotation_id].line_size = size;
@@ -468,7 +468,7 @@ export class AnnotationResizeItem extends ToolboxItem {
             for (const annotation_id in subtask.annotations.access) {
                 subtask.annotations.access[annotation_id].line_size += size;
                 //temporary solution
-                this[subtask_cashed_size] = subtask.annotations.access[annotation_id].line_size
+                this[subtask_cached_size] = subtask.annotations.access[annotation_id].line_size
             }
             this.set_size_cookie(subtask.annotations.access[subtask.annotations.ordering[0]].line_size, subtask)
             return;
@@ -483,7 +483,7 @@ export class AnnotationResizeItem extends ToolboxItem {
                     subtask.annotations.access[annotation_id].line_size -= size;
                 }
                 //temporary solution
-                this[subtask_cashed_size] = subtask.annotations.access[annotation_id].line_size
+                this[subtask_cached_size] = subtask.annotations.access[annotation_id].line_size
             }
             this.set_size_cookie(subtask.annotations.access[subtask.annotations.ordering[0]].line_size, subtask)
             return;


### PR DESCRIPTION
# Vanish all subtasks

## Description

Proposed in #75 
Pressing the "V" key will vanish all subtasks. Technically it swaps the vanished state of all subtasks, so if one subtask is vanished and one is not then they will switch, which seems like preferred behavior to me. 

## PR Checklist

- [ ] Merged latest main
- [ ] Version number in `package.json` has been bumped since last release
- [ ] Version numbers match between package `package.json` and `src/version.js`
- [ ] Ran `npm install` and `npm run build` AFTER bumping the version number
- [ ] Updated documentation if necessary (currently just in `api_spec.md`)
- [ ] Added changes to `changelog.md`

## Breaking API Changes

none
