### PR TITLE
Delete on hover

### DIFF
--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -15300,6 +15300,15 @@ class ULabel {
             }
             ul.suggest_edits(null);
         });
+        jquery_default()(document).on("keypress", (e) => {
+            if (e.key == "d") {
+                console.log(ul)
+                if (ul.subtasks[ul.state["current_subtask"]]["active_annotation"] != null) {
+                    console.log("delete attempted")
+                    ul.delete_annotation(ul.subtasks[ul.state["current_subtask"]]["active_annotation"])
+                }
+            }   
+        })
 
         // Listener for id_dialog click interactions
         jquery_default()(document).on("click", "#" + ul.config["container_id"] + " a.id-dialog-clickable-indicator", (e) => {
@@ -18729,6 +18738,7 @@ class ULabel {
      */  
     suggest_edits(mouse_event = null, nonspatial_id = null) {
         let best_candidate;
+        console.log(this.subtasks[this.state["current_subtask"]]["active_annotation"]);
         if (nonspatial_id == null) {
             if (mouse_event == null) {
                 mouse_event = this.state["last_move"];
@@ -18750,6 +18760,7 @@ class ULabel {
                 this.hide_global_edit_suggestion();
                 this.hide_edit_suggestion();
                 this.subtasks[this.state["current_subtask"]]["state"]["move_candidate"] = null;
+                this.subtasks[this.state["current_subtask"]]["active_annotation"] = null;
                 return;
             }
 
@@ -18782,6 +18793,7 @@ class ULabel {
             best_candidate = nonspatial_id;
         }
         this.show_global_edit_suggestion(best_candidate, null, nonspatial_id);
+        this.subtasks[this.state["current_subtask"]]["active_annotation"] = best_candidate
     }
 
 

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -11726,6 +11726,7 @@ var Configuration = /** @class */ (function () {
             "annotation_vanish": "v" //The v Key by default
         };
         this.default_annotation_size = 6;
+        this.delete_annotation_keybind = "d";
         this.filter_annotations_on_load = false;
         this.modify_config.apply(this, kwargs);
     }
@@ -15301,7 +15302,7 @@ class ULabel {
             ul.suggest_edits(null);
         });
         jquery_default()(document).on("keypress", (e) => {
-            if (e.key == "d") {
+            if (e.key == ul.config.delete_annotation_keybind) {
                 console.log(ul)
                 if (ul.subtasks[ul.state["current_subtask"]]["active_annotation"] != null) {
                     console.log("delete attempted")

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -56,6 +56,7 @@ var Configuration = /** @class */ (function () {
             "annotation_vanish": "v" //The v Key by default
         };
         this.default_annotation_size = 6;
+        this.delete_annotation_keybind = "d";
         this.filter_annotations_on_load = false;
         this.modify_config.apply(this, kwargs);
     }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -53,6 +53,8 @@ export class Configuration {
 
     public default_annotation_size: number = 6;
 
+    public delete_annotation_keybind: string = "d";
+
     public filter_low_confidence_default_value: number;
 
     public filter_annotations_on_load: boolean = false;

--- a/src/index.js
+++ b/src/index.js
@@ -779,7 +779,7 @@ export class ULabel {
             ul.suggest_edits(null);
         });
         $(document).on("keypress", (e) => {
-            if (e.key == "d") {
+            if (e.key == ul.config.delete_annotation_keybind) {
                 console.log(ul)
                 if (ul.subtasks[ul.state["current_subtask"]]["active_annotation"] != null) {
                     console.log("delete attempted")

--- a/src/index.js
+++ b/src/index.js
@@ -778,6 +778,15 @@ export class ULabel {
             }
             ul.suggest_edits(null);
         });
+        $(document).on("keypress", (e) => {
+            if (e.key == "d") {
+                console.log(ul)
+                if (ul.subtasks[ul.state["current_subtask"]]["active_annotation"] != null) {
+                    console.log("delete attempted")
+                    ul.delete_annotation(ul.subtasks[ul.state["current_subtask"]]["active_annotation"])
+                }
+            }   
+        })
 
         // Listener for id_dialog click interactions
         $(document).on("click", "#" + ul.config["container_id"] + " a.id-dialog-clickable-indicator", (e) => {
@@ -4207,6 +4216,7 @@ export class ULabel {
      */  
     suggest_edits(mouse_event = null, nonspatial_id = null) {
         let best_candidate;
+        console.log(this.subtasks[this.state["current_subtask"]]["active_annotation"]);
         if (nonspatial_id == null) {
             if (mouse_event == null) {
                 mouse_event = this.state["last_move"];
@@ -4228,6 +4238,7 @@ export class ULabel {
                 this.hide_global_edit_suggestion();
                 this.hide_edit_suggestion();
                 this.subtasks[this.state["current_subtask"]]["state"]["move_candidate"] = null;
+                this.subtasks[this.state["current_subtask"]]["active_annotation"] = null;
                 return;
             }
 
@@ -4260,6 +4271,7 @@ export class ULabel {
             best_candidate = nonspatial_id;
         }
         this.show_global_edit_suggestion(best_candidate, null, nonspatial_id);
+        this.subtasks[this.state["current_subtask"]]["active_annotation"] = best_candidate
     }
 
 


### PR DESCRIPTION
# Add keybind to delete annotation on hover

## Description

Proposed in #76 
Added a keybind to delete the "active" annotation. Currently the keybind is set to "d", but it can be changed in the config.

## PR Checklist

- [ ] Merged latest main
- [ ] Version number in `package.json` has been bumped since last release
- [ ] Version numbers match between package `package.json` and `src/version.js`
- [ ] Ran `npm install` and `npm run build` AFTER bumping the version number
- [ ] Updated documentation if necessary (currently just in `api_spec.md`)
- [ ] Added changes to `changelog.md`

## Breaking API Changes

None
