### PR TITLE
Add keybind to switch between subtasks

### DIFF
--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -11729,6 +11729,7 @@ var Configuration = /** @class */ (function () {
         this.default_annotation_size = 6;
         this.delete_annotation_keybind = "d";
         this.filter_annotations_on_load = false;
+        this.switch_subtask_keybind = "z";
         this.modify_config.apply(this, kwargs);
     }
     Configuration.prototype.modify_config = function () {
@@ -15358,6 +15359,40 @@ class ULabel {
 
             ul.set_subtask(switch_to);
         });
+
+        // Keybind to switch active subtask
+        jquery_default()(document).on("keypress", (e) => {
+            
+            // Ignore if in the middle of annotation
+            if (ul.subtasks[ul.state["current_subtask"]]["state"]["is_in_progress"]) {
+                return;
+            }
+
+            // Check for the right keypress
+            if (e.key == ul.config.switch_subtask_keybind) {
+
+                let current_subtask = ul.state["current_subtask"];
+                let toolbox_tab_keys = [];
+    
+                // Put all of the toolbox tab keys in a list
+                for(let idx in ul.toolbox.tabs) {
+                    toolbox_tab_keys.push(ul.toolbox.tabs[idx].subtask_key);
+                }
+    
+                // Get the index of the next subtask in line
+                let new_subtask_index = toolbox_tab_keys.indexOf(current_subtask) + 1;  // +1 gets the next subtask
+    
+                // If the current subtask was the last one in the array, then
+                // loop around to the first subtask
+                if (new_subtask_index == toolbox_tab_keys.length) {
+                    new_subtask_index = 0;
+                }
+    
+                let new_subtask = toolbox_tab_keys[new_subtask_index];
+    
+                ul.set_subtask(new_subtask);
+            }
+        })
 
         jquery_default()(document).on("input", "input.frame_input", () => {
             ul.update_frame();

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -59,6 +59,7 @@ var Configuration = /** @class */ (function () {
         this.default_annotation_size = 6;
         this.delete_annotation_keybind = "d";
         this.filter_annotations_on_load = false;
+        this.switch_subtask_keybind = "z";
         this.modify_config.apply(this, kwargs);
     }
     Configuration.prototype.modify_config = function () {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -61,6 +61,8 @@ export class Configuration {
 
     public filter_annotations_on_load: boolean = false;
 
+    public switch_subtask_keybind: string = "z";
+
     public static annotation_gradient_default: boolean = false;
 
     constructor(...kwargs: {[key: string]: unknown}[]) {

--- a/src/index.js
+++ b/src/index.js
@@ -835,6 +835,40 @@ export class ULabel {
             ul.set_subtask(switch_to);
         });
 
+        // Keybind to switch active subtask
+        $(document).on("keypress", (e) => {
+            
+            // Ignore if in the middle of annotation
+            if (ul.subtasks[ul.state["current_subtask"]]["state"]["is_in_progress"]) {
+                return;
+            }
+
+            // Check for the right keypress
+            if (e.key == ul.config.switch_subtask_keybind) {
+
+                let current_subtask = ul.state["current_subtask"];
+                let toolbox_tab_keys = [];
+    
+                // Put all of the toolbox tab keys in a list
+                for(let idx in ul.toolbox.tabs) {
+                    toolbox_tab_keys.push(ul.toolbox.tabs[idx].subtask_key);
+                }
+    
+                // Get the index of the next subtask in line
+                let new_subtask_index = toolbox_tab_keys.indexOf(current_subtask) + 1;  // +1 gets the next subtask
+    
+                // If the current subtask was the last one in the array, then
+                // loop around to the first subtask
+                if (new_subtask_index == toolbox_tab_keys.length) {
+                    new_subtask_index = 0;
+                }
+    
+                let new_subtask = toolbox_tab_keys[new_subtask_index];
+    
+                ul.set_subtask(new_subtask);
+            }
+        })
+
         $(document).on("input", "input.frame_input", () => {
             ul.update_frame();
         });


### PR DESCRIPTION
# Switch between subtasks with keybind

## Description

Proposed in #45 

Adds a keybind to switch between active subtasks. Currently the keybind is z but is able to be changed in the config.

## PR Checklist

- [ ] Merged latest main
- [ ] Version number in `package.json` has been bumped since last release
- [ ] Version numbers match between package `package.json` and `src/version.js`
- [ ] Ran `npm install` and `npm run build` AFTER bumping the version number
- [ ] Updated documentation if necessary (currently just in `api_spec.md`)
- [ ] Added changes to `changelog.md`

## Breaking API Changes

none
