### PR TITLE
Add support for an arbitrary quantity of submit buttons

### DIFF
--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -20627,7 +20627,7 @@ var SubmitButtons = /** @class */ (function (_super) {
         var _loop_1 = function (idx) {
             // Create a unique event listener for each submit button in the submit buttons array.
             $(document).on("click", "#" + this_1.submit_buttons[idx].name.replaceLowerConcat(" ", "-"), function () { return __awaiter(_this, void 0, void 0, function () {
-                var button, submit_payload, stkey, i;
+                var button, animation, submit_payload, stkey, i;
                 return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
@@ -20635,7 +20635,11 @@ var SubmitButtons = /** @class */ (function (_super) {
                             console.log(button);
                             // Set the button to disabled until we're done processing the previous click
                             button.disabled = true;
-                            button.innerText = "( )";
+                            button.innerText = "";
+                            button.style.filter = "opacity(0.7)";
+                            animation = document.createElement("div");
+                            animation.className = "lds-dual-ring";
+                            button.appendChild(animation);
                             submit_payload = {
                                 "task_meta": ulabel.config["task_meta"],
                                 "annotations": {}
@@ -20654,6 +20658,7 @@ var SubmitButtons = /** @class */ (function (_super) {
                             // Set the button back to its initial state
                             button.disabled = false;
                             button.innerText = this.submit_buttons[idx].name;
+                            button.style.filter = "opacity(1)";
                             return [2 /*return*/];
                     }
                 });
@@ -20676,7 +20681,7 @@ var SubmitButtons = /** @class */ (function (_super) {
                 // If no color provided use hard coded default
                 button_color = "rgba(255, 166, 0, 0.739)";
             }
-            toolboxitem_html += "\n            <button \n            id=\"".concat(this.submit_buttons[idx].name.replaceLowerConcat(" ", "-"), "\" \n            class=\"submit-button\" \n            style=\"\n                display: block;\n                width: 6em;\n                font-size: 1.5em;\n                color: white;\n                background-color: ").concat(button_color, "; \n                margin-left: auto;\n                margin-right: auto;\n                margin-top: 0.5em;\n                margin-bottom: 0.5em;\n                padding: 1em;\n                border: 1px solid ").concat(button_color, ";\n                border-radius: 0.5em;\n                cursor: pointer;\n            \">\n                ").concat(this.submit_buttons[idx].name, "\n            </button>\n            ");
+            toolboxitem_html += "\n            <button \n            id=\"".concat(this.submit_buttons[idx].name.replaceLowerConcat(" ", "-"), "\" \n            class=\"submit-button\" \n            style=\"\n                display: block;\n                height: 1.2em;\n                width: 6em;\n                font-size: 1.5em;\n                color: white;\n                background-color: ").concat(button_color, "; \n                margin-left: auto;\n                margin-right: auto;\n                margin-top: 0.5em;\n                margin-bottom: 0.5em;\n                padding: 1em;\n                border: 1px solid ").concat(button_color, ";\n                border-radius: 0.5em;\n                cursor: pointer;\n            \">\n                ").concat(this.submit_buttons[idx].name, "\n            </button>\n            ");
         }
         return toolboxitem_html;
     };

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -20615,11 +20615,9 @@ var SubmitButtons = /** @class */ (function (_super) {
     __extends(SubmitButtons, _super);
     function SubmitButtons(ulabel) {
         var _this = _super.call(this) || this;
-        _this.click = "clicked";
         _this.submit_buttons = ulabel.config.submit_buttons;
-        console.log(_this.submit_buttons);
-        console.log(_this.my_function);
         var _loop_1 = function (idx) {
+            // Create a unique event listener for each submit button in the submit buttons array.
             $(document).on("click", "#" + this_1.submit_buttons[idx].name.replaceLowerConcat(" ", "-"), function () { return __awaiter(_this, void 0, void 0, function () {
                 var submit_payload, stkey, i;
                 return __generator(this, function (_a) {
@@ -20638,7 +20636,9 @@ var SubmitButtons = /** @class */ (function (_super) {
                                 }
                             }
                             return [4 /*yield*/, this.submit_buttons[idx].hook(submit_payload)];
-                        case 1: return [2 /*return*/, _a.sent()];
+                        case 1:
+                            _a.sent();
+                            return [2 /*return*/];
                     }
                 });
             }); });
@@ -20649,13 +20649,9 @@ var SubmitButtons = /** @class */ (function (_super) {
         }
         return _this;
     }
-    SubmitButtons.prototype.my_function = function () {
-        this.button_holder_name;
-    };
     SubmitButtons.prototype.get_html = function () {
         var toolboxitem_html = "";
         for (var idx in this.submit_buttons) {
-            console.log("inside submit button creator", idx);
             var button_color = void 0;
             if (this.submit_buttons[idx].color !== undefined) {
                 button_color = this.submit_buttons[idx].color;
@@ -20664,7 +20660,7 @@ var SubmitButtons = /** @class */ (function (_super) {
                 // If no color provided use hard coded default
                 button_color = "rgba(255, 166, 0, 0.739)";
             }
-            toolboxitem_html += "\n            <button \n            id=\"".concat(this.submit_buttons[idx].name.replaceLowerConcat(" ", "-"), "\" \n            class=\"submit-button\" \n            style=\"\n                display: block;\n                width: 6em;\n                font-size: 1.5em;\n                color: white;\n                background-color: ").concat(button_color, "; \n                margin-left: auto;\n                margin-right: auto;\n                margin-top: 0.5em;\n                margin-bottom: 0.5em;\n                padding: 1em;\n                border: 1px solid ").concat(button_color, ";\n                border-radius: 0.5em;\n            \">\n                ").concat(this.submit_buttons[idx].name, "\n            </button>\n            ");
+            toolboxitem_html += "\n            <button \n            id=\"".concat(this.submit_buttons[idx].name.replaceLowerConcat(" ", "-"), "\" \n            class=\"submit-button\" \n            style=\"\n                display: block;\n                width: 6em;\n                font-size: 1.5em;\n                color: white;\n                background-color: ").concat(button_color, "; \n                margin-left: auto;\n                margin-right: auto;\n                margin-top: 0.5em;\n                margin-bottom: 0.5em;\n                padding: 1em;\n                border: 1px solid ").concat(button_color, ";\n                border-radius: 0.5em;\n                cursor: pointer;\n            \">\n                ").concat(this.submit_buttons[idx].name, "\n            </button>\n            ");
         }
         return toolboxitem_html;
     };

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -11682,6 +11682,7 @@ var AllowedToolboxItem;
     AllowedToolboxItem[AllowedToolboxItem["RecolorActive"] = 4] = "RecolorActive";
     AllowedToolboxItem[AllowedToolboxItem["ClassCounter"] = 5] = "ClassCounter";
     AllowedToolboxItem[AllowedToolboxItem["KeypointSlider"] = 6] = "KeypointSlider";
+    AllowedToolboxItem[AllowedToolboxItem["SubmitButtons"] = 7] = "SubmitButtons";
 })(AllowedToolboxItem || (AllowedToolboxItem = {}));
 var Configuration = /** @class */ (function () {
     function Configuration() {
@@ -11696,7 +11697,8 @@ var Configuration = /** @class */ (function () {
             [AllowedToolboxItem.AnnotationID, toolbox_1.AnnotationIDToolboxItem],
             [AllowedToolboxItem.RecolorActive, toolbox_1.RecolorActiveItem],
             [AllowedToolboxItem.ClassCounter, toolbox_1.ClassCounterToolboxItem],
-            [AllowedToolboxItem.KeypointSlider, toolbox_1.KeypointSliderItem]
+            [AllowedToolboxItem.KeypointSlider, toolbox_1.KeypointSliderItem],
+            [AllowedToolboxItem.SubmitButtons, toolbox_1.SubmitButtons]
         ]);
         //Change the order of the toolbox items here to change the order they show up in the toolbox
         this.default_toolbox_item_order = [
@@ -11716,7 +11718,8 @@ var Configuration = /** @class */ (function () {
                         "increment": "2",
                         "decrement": "1"
                     }
-                }]
+                }],
+            AllowedToolboxItem.SubmitButtons,
         ];
         this.default_keybinds = {
             "annotation_size_small": "s",
@@ -14780,7 +14783,6 @@ class ULabel {
             if (typeof(toolbox_item_order[i]) == "number") {
                 toolbox_key = toolbox_item_order[i]
             } else {
-
                 toolbox_key = toolbox_item_order[i][0];
                 args = toolbox_item_order[i][1]  
             }
@@ -14791,8 +14793,8 @@ class ULabel {
                 toolbox_instance_list.push(new toolbox_item_class(ulabel))
             } else {
                 toolbox_instance_list.push(new toolbox_item_class(ulabel, args))
-            }           
-        }
+            }  
+        }                    
 
         return toolbox_instance_list
     }
@@ -14841,9 +14843,9 @@ class ULabel {
         // Append but don't wait
         jquery_default()("#" + sp_id + " .toolbox_inner_cls .mode-selection").append(md_buttons.join("<!-- -->"));
         // TODO noconflict
-        jquery_default()("#" + sp_id + " .toolbox_inner_cls").append(`
-            <a id="submit-button" href="#">${ul.config["done_button"]}</a>
-        `);
+        // $("#" + sp_id + " .toolbox_inner_cls").append(`
+        //     <a id="submit-button" href="#">${ul.config["done_button"]}</a>
+        // `);
 
         // Show current mode label
         ul.show_annotation_mode();
@@ -15501,32 +15503,32 @@ class ULabel {
         })
 
         // Button to save annotations
-        jquery_default()(document).on("click", `a#submit-button[href="#"]`, async () => {
-            var submit_payload = {
-                "task_meta": ul.config["task_meta"],
-                "annotations": {}
-            };
-            for (const stkey in ul.subtasks) {
-                submit_payload["annotations"][stkey] = [];
-                for (var i = 0; i < ul.subtasks[stkey]["annotations"]["ordering"].length; i++) {
-                    submit_payload["annotations"][stkey].push(
-                        ul.subtasks[stkey]["annotations"]["access"][
-                        ul.subtasks[stkey]["annotations"]["ordering"][i]
-                        ]
-                    );
-                }
-            }
-            ul.set_saved(false, true);
-            try {
-                const save_success = await ul.config["done_callback"].bind(ul)(submit_payload);
-                ul.set_saved(!(save_success === false));
-            }
-            catch (err) {
-                console.log("Error waiting for submit script.")
-                console.log(err);
-                ul.set_saved(false);
-            }
-        });
+        // $(document).on("click", `a#submit-button[href="#"]`, async () => {
+        //     var submit_payload = {
+        //         "task_meta": ul.config["task_meta"],
+        //         "annotations": {}
+        //     };
+        //     for (const stkey in ul.subtasks) {
+        //         submit_payload["annotations"][stkey] = [];
+        //         for (var i = 0; i < ul.subtasks[stkey]["annotations"]["ordering"].length; i++) {
+        //             submit_payload["annotations"][stkey].push(
+        //                 ul.subtasks[stkey]["annotations"]["access"][
+        //                 ul.subtasks[stkey]["annotations"]["ordering"][i]
+        //                 ]
+        //             );
+        //         }
+        //     }
+        //     ul.set_saved(false, true);
+        //     try {
+        //         const save_success = await ul.config["done_callback"].bind(ul)(submit_payload);
+        //         ul.set_saved(!(save_success === false));
+        //     }
+        //     catch (err) {
+        //         console.log("Error waiting for submit script.")
+        //         console.log(err);
+        //         ul.set_saved(false);
+        //     }
+        // });
 
         jquery_default()(document).on("click", "#" + ul.config["toolbox_id"] + " a.night-button", function () {
             if (jquery_default()("#" + ul.config["container_id"]).hasClass("ulabel-night")) {
@@ -15916,7 +15918,7 @@ class ULabel {
         container_id,
         image_data,
         username,
-        on_submit,
+        submit_buttons,
         subtasks,
         task_meta = null,
         annotation_meta = null,
@@ -15927,32 +15929,40 @@ class ULabel {
         config_data = null
     ) {
         console.log(this)
-        // Unroll safe default arguments
-        if (task_meta == null) { task_meta = {}; }
-        if (annotation_meta == null) { annotation_meta = {}; }
+        // // Unroll safe default arguments
+        // if (task_meta == null) { task_meta = {}; }
+        // if (annotation_meta == null) { annotation_meta = {}; }
 
-        // Unroll submit button
-        let on_submit_unrolled;
-        if (typeof on_submit == "function") {
-            on_submit_unrolled = {
-                name: "Submit",
-                hook: on_submit
-            };
-        }
-        else {
-            on_submit_unrolled = on_submit;
-        }
 
-        // If on_submit hook is not async, wrap it in an async func
-        let fin_on_submit_hook;
-        if (on_submit_unrolled.hook.constructor.name == "AsyncFunction") {
-            fin_on_submit_hook = on_submit_unrolled.hook;
-        }
-        else {
-            fin_on_submit_hook = async function (annotations) {
-                return on_submit_unrolled.hook(annotations);
-            };
-        }
+        // if (Array.isArray(submit_buttons)) {
+        //     this.buttons
+        // }
+
+
+        // // Unroll submit button
+        // let on_submit_unrolled;
+        // if (typeof submit_buttons == "function") {
+        //     on_submit_unrolled = {
+        //         name: "Submit",
+        //         hook: submit_buttons
+        //     };
+        // }
+        // else {
+        //     on_submit_unrolled = submit_buttons;
+        // }
+
+        // // If on_submit hook is not async, wrap it in an async func
+        // let fin_on_submit_hook;
+        // if (on_submit_unrolled.hook.constructor.name == "AsyncFunction") {
+        //     fin_on_submit_hook = on_submit_unrolled.hook;
+        // }
+        // else {
+        //     fin_on_submit_hook = async function (annotations) {
+        //         return on_submit_unrolled.hook(annotations);
+        //     };
+        // }
+
+        // this.submit_buttons1 = on_submit_unrolled
 
         // TODO 
         // Allow for importing spacing data -- a measure tool would be nice too
@@ -15991,9 +16001,10 @@ class ULabel {
             "edit_handle_size": 30,
 
             // Behavior on special interactions
-            "done_callback": fin_on_submit_hook,
-            "done_button": on_submit_unrolled.name,
+            // "done_callback": fin_on_submit_hook,
+            // "done_button": on_submit_unrolled.name,
             "instructions_url": instructions_url,
+            "submit_buttons": submit_buttons,
 
             // ID Dialog config
             "cl_opacity": 0.4,
@@ -19795,6 +19806,42 @@ var __extends = (this && this.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.SubmitButtons = exports.KeypointSliderItem = exports.RecolorActiveItem = exports.AnnotationResizeItem = exports.ClassCounterToolboxItem = exports.AnnotationIDToolboxItem = exports.ZoomPanToolboxItem = exports.ModeSelectionToolboxItem = exports.ToolboxItem = exports.ToolboxTab = exports.Toolbox = void 0;
 var __1 = __webpack_require__(318);
@@ -20566,14 +20613,49 @@ var KeypointSliderItem = /** @class */ (function (_super) {
 exports.KeypointSliderItem = KeypointSliderItem;
 var SubmitButtons = /** @class */ (function (_super) {
     __extends(SubmitButtons, _super);
-    function SubmitButtons(sumbit_buttons) {
+    function SubmitButtons(ulabel) {
         var _this = _super.call(this) || this;
-        _this.submit_buttons = sumbit_buttons;
+        _this.click = "clicked";
+        _this.submit_buttons = ulabel.config.submit_buttons;
+        console.log(_this.submit_buttons);
+        console.log(_this.my_function);
+        var _loop_1 = function (idx) {
+            $(document).on("click", "#" + this_1.submit_buttons[idx].name.replaceLowerConcat(" ", "-"), function () { return __awaiter(_this, void 0, void 0, function () {
+                var submit_payload, stkey, i;
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0:
+                            submit_payload = {
+                                "task_meta": ulabel.config["task_meta"],
+                                "annotations": {}
+                            };
+                            // Loop through all of the subtasks
+                            for (stkey in ulabel.subtasks) {
+                                submit_payload["annotations"][stkey] = [];
+                                // Add all of the annotations in that subtask
+                                for (i = 0; i < ulabel.subtasks[stkey]["annotations"]["ordering"].length; i++) {
+                                    submit_payload["annotations"][stkey].push(ulabel.subtasks[stkey]["annotations"]["access"][ulabel.subtasks[stkey]["annotations"]["ordering"][i]]);
+                                }
+                            }
+                            return [4 /*yield*/, this.submit_buttons[idx].hook(submit_payload)];
+                        case 1: return [2 /*return*/, _a.sent()];
+                    }
+                });
+            }); });
+        };
+        var this_1 = this;
+        for (var idx in _this.submit_buttons) {
+            _loop_1(idx);
+        }
         return _this;
     }
+    SubmitButtons.prototype.my_function = function () {
+        this.button_holder_name;
+    };
     SubmitButtons.prototype.get_html = function () {
         var toolboxitem_html = "";
         for (var idx in this.submit_buttons) {
+            console.log("inside submit button creator", idx);
             var button_color = void 0;
             if (this.submit_buttons[idx].color !== undefined) {
                 button_color = this.submit_buttons[idx].color;
@@ -20582,7 +20664,7 @@ var SubmitButtons = /** @class */ (function (_super) {
                 // If no color provided use hard coded default
                 button_color = "rgba(255, 166, 0, 0.739)";
             }
-            toolboxitem_html += "\n            <button onclick=\"".concat(this.submit_buttons[idx].hook, "\" background-color=\"").concat(button_color, "\">\n                ").concat(this.submit_buttons[idx].name, "\n            </button>\n            ");
+            toolboxitem_html += "\n            <button \n            id=\"".concat(this.submit_buttons[idx].name.replaceLowerConcat(" ", "-"), "\" \n            class=\"submit-button\" \n            style=\"\n                background-color: ").concat(button_color, "; \n                display: block;\n                margin-left: auto;\n                margin-right: auto;\n                margin-top: 0.5em;\n                margin-bottom: 0.5em;\n                padding: 2em;\n            \">\n                ").concat(this.submit_buttons[idx].name, "\n            </button>\n            ");
         }
         return toolboxitem_html;
     };

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -14842,10 +14842,6 @@ class ULabel {
 
         // Append but don't wait
         jquery_default()("#" + sp_id + " .toolbox_inner_cls .mode-selection").append(md_buttons.join("<!-- -->"));
-        // TODO noconflict
-        // $("#" + sp_id + " .toolbox_inner_cls").append(`
-        //     <a id="submit-button" href="#">${ul.config["done_button"]}</a>
-        // `);
 
         // Show current mode label
         ul.show_annotation_mode();
@@ -15573,7 +15569,7 @@ class ULabel {
                 )
             ) {
                 keypress_event.preventDefault();
-                jquery_default()("a#submit-button").trigger("click");
+                jquery_default()(".submit-button")[0].click(); // Click the first submit button
             }
             else if (keypress_event.key == "l") {
                 // console.log("Listing annotations using the \"l\" key has been deprecated.");

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -20626,17 +20626,20 @@ var SubmitButtons = /** @class */ (function (_super) {
         }
         var _loop_1 = function (idx) {
             // Create a unique event listener for each submit button in the submit buttons array.
-            $(document).on("click", "#" + this_1.submit_buttons[idx].name.replaceLowerConcat(" ", "-"), function () { return __awaiter(_this, void 0, void 0, function () {
-                var button, animation, submit_payload, stkey, i;
+            $(document).on("click", "#" + this_1.submit_buttons[idx].name.replaceLowerConcat(" ", "-"), function (e) { return __awaiter(_this, void 0, void 0, function () {
+                var button, submit_button_elements, i, animation, submit_payload, stkey, i, i;
                 return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             button = document.getElementById(this.submit_buttons[idx].name.replaceLowerConcat(" ", "-"));
-                            console.log(button);
-                            // Set the button to disabled until we're done processing the previous click
-                            button.disabled = true;
+                            submit_button_elements = Array.from(document.getElementsByClassName("submit-button"));
+                            // Make all the buttons look disabled
+                            for (i in submit_button_elements) {
+                                submit_button_elements[i].disabled = true;
+                                submit_button_elements[i].style.filter = "opacity(0.7)";
+                            }
+                            // Give the clicked button a loading animation
                             button.innerText = "";
-                            button.style.filter = "opacity(0.7)";
                             animation = document.createElement("div");
                             animation.className = "lds-dual-ring";
                             button.appendChild(animation);
@@ -20655,10 +20658,13 @@ var SubmitButtons = /** @class */ (function (_super) {
                             return [4 /*yield*/, this.submit_buttons[idx].hook(submit_payload)];
                         case 1:
                             _a.sent();
-                            // Set the button back to its initial state
-                            button.disabled = false;
+                            // Give the button back its name
                             button.innerText = this.submit_buttons[idx].name;
-                            button.style.filter = "opacity(1)";
+                            // Re-enable the buttons
+                            for (i in submit_button_elements) {
+                                submit_button_elements[i].disabled = false;
+                                submit_button_elements[i].style.filter = "opacity(1)";
+                            }
                             return [2 /*return*/];
                     }
                 });

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -20615,7 +20615,15 @@ var SubmitButtons = /** @class */ (function (_super) {
     __extends(SubmitButtons, _super);
     function SubmitButtons(ulabel) {
         var _this = _super.call(this) || this;
+        // Grab the submit buttons from ulabel
         _this.submit_buttons = ulabel.config.submit_buttons;
+        // For legacy reasons submit_buttons may be a function, in that case convert it to the right format
+        if (typeof _this.submit_buttons == "function") {
+            _this.submit_buttons = [{
+                    "name": "Submit",
+                    "hook": _this.submit_buttons
+                }];
+        }
         var _loop_1 = function (idx) {
             // Create a unique event listener for each submit button in the submit buttons array.
             $(document).on("click", "#" + this_1.submit_buttons[idx].name.replaceLowerConcat(" ", "-"), function () { return __awaiter(_this, void 0, void 0, function () {

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -20619,10 +20619,15 @@ var SubmitButtons = /** @class */ (function (_super) {
         var _loop_1 = function (idx) {
             // Create a unique event listener for each submit button in the submit buttons array.
             $(document).on("click", "#" + this_1.submit_buttons[idx].name.replaceLowerConcat(" ", "-"), function () { return __awaiter(_this, void 0, void 0, function () {
-                var submit_payload, stkey, i;
+                var button, submit_payload, stkey, i;
                 return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
+                            button = document.getElementById(this.submit_buttons[idx].name.replaceLowerConcat(" ", "-"));
+                            console.log(button);
+                            // Set the button to disabled until we're done processing the previous click
+                            button.disabled = true;
+                            button.innerText = "( )";
                             submit_payload = {
                                 "task_meta": ulabel.config["task_meta"],
                                 "annotations": {}
@@ -20638,6 +20643,9 @@ var SubmitButtons = /** @class */ (function (_super) {
                             return [4 /*yield*/, this.submit_buttons[idx].hook(submit_payload)];
                         case 1:
                             _a.sent();
+                            // Set the button back to its initial state
+                            button.disabled = false;
+                            button.innerText = this.submit_buttons[idx].name;
                             return [2 /*return*/];
                     }
                 });

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -14530,7 +14530,7 @@ div#${prntid}.ulabel-night #submit-button[href="#"]:active {
 `;
 }
 
-const BUTTON_LOADER_HTML = `<div class="lds-dual-ring"></div>`;
+const BUTTON_LOADER_HTML = (/* unused pure expression or super */ null && (`<div class="lds-dual-ring"></div>`));
 
 // TODO more of these
 const COLORS = [
@@ -17619,19 +17619,19 @@ class ULabel {
     // Action Stream Events
 
     set_saved(saved, in_progress = false) {
-        if (saved) {
-            jquery_default()("#" + this.config["container_id"] + " a#submit-button").removeAttr("href");
-            jquery_default()("#" + this.config["container_id"] + " a#submit-button").html(this.config["done_button"]);
-        }
-        else {
-            jquery_default()("#" + this.config["container_id"] + " a#submit-button").attr("href", "#");
-            if (in_progress) {
-                jquery_default()("#" + this.config["container_id"] + " a#submit-button").html(BUTTON_LOADER_HTML);
-            }
-            else {
-                jquery_default()("#" + this.config["container_id"] + " a#submit-button").html(this.config["done_button"]);
-            }
-        }
+        // if (saved) {
+        //     $("#" + this.config["container_id"] + " a#submit-button").removeAttr("href");
+        //     $("#" + this.config["container_id"] + " a#submit-button").html(this.config["done_button"]);
+        // }
+        // else {
+        //     $("#" + this.config["container_id"] + " a#submit-button").attr("href", "#");
+        //     if (in_progress) {
+        //         $("#" + this.config["container_id"] + " a#submit-button").html(BUTTON_LOADER_HTML);
+        //     }
+        //     else {
+        //         $("#" + this.config["container_id"] + " a#submit-button").html(this.config["done_button"]);
+        //     }
+        // }
         this.state["edited"] = !saved;
     }
 

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -20664,7 +20664,7 @@ var SubmitButtons = /** @class */ (function (_super) {
                 // If no color provided use hard coded default
                 button_color = "rgba(255, 166, 0, 0.739)";
             }
-            toolboxitem_html += "\n            <button \n            id=\"".concat(this.submit_buttons[idx].name.replaceLowerConcat(" ", "-"), "\" \n            class=\"submit-button\" \n            style=\"\n                background-color: ").concat(button_color, "; \n                display: block;\n                margin-left: auto;\n                margin-right: auto;\n                margin-top: 0.5em;\n                margin-bottom: 0.5em;\n                padding: 2em;\n            \">\n                ").concat(this.submit_buttons[idx].name, "\n            </button>\n            ");
+            toolboxitem_html += "\n            <button \n            id=\"".concat(this.submit_buttons[idx].name.replaceLowerConcat(" ", "-"), "\" \n            class=\"submit-button\" \n            style=\"\n                display: block;\n                width: 6em;\n                font-size: 1.5em;\n                color: white;\n                background-color: ").concat(button_color, "; \n                margin-left: auto;\n                margin-right: auto;\n                margin-top: 0.5em;\n                margin-bottom: 0.5em;\n                padding: 1em;\n                border: 1px solid ").concat(button_color, ";\n                border-radius: 0.5em;\n            \">\n                ").concat(this.submit_buttons[idx].name, "\n            </button>\n            ");
         }
         return toolboxitem_html;
     };

--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -19796,7 +19796,7 @@ var __extends = (this && this.__extends) || (function () {
     };
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.KeypointSliderItem = exports.RecolorActiveItem = exports.AnnotationResizeItem = exports.ClassCounterToolboxItem = exports.AnnotationIDToolboxItem = exports.ZoomPanToolboxItem = exports.ModeSelectionToolboxItem = exports.ToolboxItem = exports.ToolboxTab = exports.Toolbox = void 0;
+exports.SubmitButtons = exports.KeypointSliderItem = exports.RecolorActiveItem = exports.AnnotationResizeItem = exports.ClassCounterToolboxItem = exports.AnnotationIDToolboxItem = exports.ZoomPanToolboxItem = exports.ModeSelectionToolboxItem = exports.ToolboxItem = exports.ToolboxTab = exports.Toolbox = void 0;
 var __1 = __webpack_require__(318);
 var configuration_1 = __webpack_require__(976);
 var toolboxDividerDiv = "<div class=toolbox-divider></div>";
@@ -20564,6 +20564,31 @@ var KeypointSliderItem = /** @class */ (function (_super) {
     return KeypointSliderItem;
 }(ToolboxItem));
 exports.KeypointSliderItem = KeypointSliderItem;
+var SubmitButtons = /** @class */ (function (_super) {
+    __extends(SubmitButtons, _super);
+    function SubmitButtons(sumbit_buttons) {
+        var _this = _super.call(this) || this;
+        _this.submit_buttons = sumbit_buttons;
+        return _this;
+    }
+    SubmitButtons.prototype.get_html = function () {
+        var toolboxitem_html = "";
+        for (var idx in this.submit_buttons) {
+            var button_color = void 0;
+            if (this.submit_buttons[idx].color !== undefined) {
+                button_color = this.submit_buttons[idx].color;
+            }
+            else {
+                // If no color provided use hard coded default
+                button_color = "rgba(255, 166, 0, 0.739)";
+            }
+            toolboxitem_html += "\n            <button onclick=\"".concat(this.submit_buttons[idx].hook, "\" background-color=\"").concat(button_color, "\">\n                ").concat(this.submit_buttons[idx].name, "\n            </button>\n            ");
+        }
+        return toolboxitem_html;
+    };
+    return SubmitButtons;
+}(ToolboxItem));
+exports.SubmitButtons = SubmitButtons;
 // export class WholeImageClassifierToolboxTab extends ToolboxItem {
 //     constructor() {
 //         super(

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -12,6 +12,7 @@ var AllowedToolboxItem;
     AllowedToolboxItem[AllowedToolboxItem["RecolorActive"] = 4] = "RecolorActive";
     AllowedToolboxItem[AllowedToolboxItem["ClassCounter"] = 5] = "ClassCounter";
     AllowedToolboxItem[AllowedToolboxItem["KeypointSlider"] = 6] = "KeypointSlider";
+    AllowedToolboxItem[AllowedToolboxItem["SubmitButtons"] = 7] = "SubmitButtons";
 })(AllowedToolboxItem || (AllowedToolboxItem = {}));
 var Configuration = /** @class */ (function () {
     function Configuration() {
@@ -26,7 +27,8 @@ var Configuration = /** @class */ (function () {
             [AllowedToolboxItem.AnnotationID, toolbox_1.AnnotationIDToolboxItem],
             [AllowedToolboxItem.RecolorActive, toolbox_1.RecolorActiveItem],
             [AllowedToolboxItem.ClassCounter, toolbox_1.ClassCounterToolboxItem],
-            [AllowedToolboxItem.KeypointSlider, toolbox_1.KeypointSliderItem]
+            [AllowedToolboxItem.KeypointSlider, toolbox_1.KeypointSliderItem],
+            [AllowedToolboxItem.SubmitButtons, toolbox_1.SubmitButtons]
         ]);
         //Change the order of the toolbox items here to change the order they show up in the toolbox
         this.default_toolbox_item_order = [
@@ -46,7 +48,8 @@ var Configuration = /** @class */ (function () {
                         "increment": "2",
                         "decrement": "1"
                     }
-                }]
+                }],
+            AllowedToolboxItem.SubmitButtons,
         ];
         this.default_keybinds = {
             "annotation_size_small": "s",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,4 +1,4 @@
-import { ModeSelectionToolboxItem, ZoomPanToolboxItem, AnnotationIDToolboxItem, ClassCounterToolboxItem, AnnotationResizeItem, RecolorActiveItem, KeypointSliderItem } from "./toolbox"
+import { ModeSelectionToolboxItem, ZoomPanToolboxItem, AnnotationIDToolboxItem, ClassCounterToolboxItem, AnnotationResizeItem, RecolorActiveItem, KeypointSliderItem, SubmitButtons } from "./toolbox"
 import { get_annotation_confidence, mark_deprecated, filter_low } from "./annotation_operators";
 
 enum AllowedToolboxItem {
@@ -8,7 +8,8 @@ enum AllowedToolboxItem {
     AnnotationID,
     RecolorActive,
     ClassCounter,
-    KeypointSlider
+    KeypointSlider,
+    SubmitButtons
 }
 
 export class Configuration {
@@ -19,7 +20,8 @@ export class Configuration {
         [AllowedToolboxItem.AnnotationID, AnnotationIDToolboxItem],
         [AllowedToolboxItem.RecolorActive, RecolorActiveItem],
         [AllowedToolboxItem.ClassCounter, ClassCounterToolboxItem],
-        [AllowedToolboxItem.KeypointSlider, KeypointSliderItem]
+        [AllowedToolboxItem.KeypointSlider, KeypointSliderItem],
+        [AllowedToolboxItem.SubmitButtons, SubmitButtons]
     ]);
     
     //Change the order of the toolbox items here to change the order they show up in the toolbox
@@ -40,7 +42,8 @@ export class Configuration {
                 "increment": "2",
                 "decrement": "1"
             }
-        }]
+        }],
+        AllowedToolboxItem.SubmitButtons,
     ]
 
     public default_keybinds = {

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ import { ULabelSubtask } from './subtask';
 import { GeometricUtils } from './geometric_utils';
 import { get_annotation_confidence, mark_deprecated, filter_low } from './annotation_operators';
 import { apply_gradient } from './drawing_utilities'
-import { Configuration } from './configuration';
+import { Configuration, AllowedToolboxItem } from './configuration';
 import $ from 'jquery';
 const jQuery = $;
 window.$ = window.jQuery = require('jquery');
@@ -253,7 +253,6 @@ export class ULabel {
             if (typeof(toolbox_item_order[i]) == "number") {
                 toolbox_key = toolbox_item_order[i]
             } else {
-
                 toolbox_key = toolbox_item_order[i][0];
                 args = toolbox_item_order[i][1]  
             }
@@ -264,8 +263,8 @@ export class ULabel {
                 toolbox_instance_list.push(new toolbox_item_class(ulabel))
             } else {
                 toolbox_instance_list.push(new toolbox_item_class(ulabel, args))
-            }           
-        }
+            }  
+        }                    
 
         return toolbox_instance_list
     }
@@ -314,9 +313,9 @@ export class ULabel {
         // Append but don't wait
         $("#" + sp_id + " .toolbox_inner_cls .mode-selection").append(md_buttons.join("<!-- -->"));
         // TODO noconflict
-        $("#" + sp_id + " .toolbox_inner_cls").append(`
-            <a id="submit-button" href="#">${ul.config["done_button"]}</a>
-        `);
+        // $("#" + sp_id + " .toolbox_inner_cls").append(`
+        //     <a id="submit-button" href="#">${ul.config["done_button"]}</a>
+        // `);
 
         // Show current mode label
         ul.show_annotation_mode();
@@ -974,32 +973,32 @@ export class ULabel {
         })
 
         // Button to save annotations
-        $(document).on("click", `a#submit-button[href="#"]`, async () => {
-            var submit_payload = {
-                "task_meta": ul.config["task_meta"],
-                "annotations": {}
-            };
-            for (const stkey in ul.subtasks) {
-                submit_payload["annotations"][stkey] = [];
-                for (var i = 0; i < ul.subtasks[stkey]["annotations"]["ordering"].length; i++) {
-                    submit_payload["annotations"][stkey].push(
-                        ul.subtasks[stkey]["annotations"]["access"][
-                        ul.subtasks[stkey]["annotations"]["ordering"][i]
-                        ]
-                    );
-                }
-            }
-            ul.set_saved(false, true);
-            try {
-                const save_success = await ul.config["done_callback"].bind(ul)(submit_payload);
-                ul.set_saved(!(save_success === false));
-            }
-            catch (err) {
-                console.log("Error waiting for submit script.")
-                console.log(err);
-                ul.set_saved(false);
-            }
-        });
+        // $(document).on("click", `a#submit-button[href="#"]`, async () => {
+        //     var submit_payload = {
+        //         "task_meta": ul.config["task_meta"],
+        //         "annotations": {}
+        //     };
+        //     for (const stkey in ul.subtasks) {
+        //         submit_payload["annotations"][stkey] = [];
+        //         for (var i = 0; i < ul.subtasks[stkey]["annotations"]["ordering"].length; i++) {
+        //             submit_payload["annotations"][stkey].push(
+        //                 ul.subtasks[stkey]["annotations"]["access"][
+        //                 ul.subtasks[stkey]["annotations"]["ordering"][i]
+        //                 ]
+        //             );
+        //         }
+        //     }
+        //     ul.set_saved(false, true);
+        //     try {
+        //         const save_success = await ul.config["done_callback"].bind(ul)(submit_payload);
+        //         ul.set_saved(!(save_success === false));
+        //     }
+        //     catch (err) {
+        //         console.log("Error waiting for submit script.")
+        //         console.log(err);
+        //         ul.set_saved(false);
+        //     }
+        // });
 
         $(document).on("click", "#" + ul.config["toolbox_id"] + " a.night-button", function () {
             if ($("#" + ul.config["container_id"]).hasClass("ulabel-night")) {
@@ -1389,7 +1388,7 @@ export class ULabel {
         container_id,
         image_data,
         username,
-        on_submit,
+        submit_buttons,
         subtasks,
         task_meta = null,
         annotation_meta = null,
@@ -1400,32 +1399,40 @@ export class ULabel {
         config_data = null
     ) {
         console.log(this)
-        // Unroll safe default arguments
-        if (task_meta == null) { task_meta = {}; }
-        if (annotation_meta == null) { annotation_meta = {}; }
+        // // Unroll safe default arguments
+        // if (task_meta == null) { task_meta = {}; }
+        // if (annotation_meta == null) { annotation_meta = {}; }
 
-        // Unroll submit button
-        let on_submit_unrolled;
-        if (typeof on_submit == "function") {
-            on_submit_unrolled = {
-                name: "Submit",
-                hook: on_submit
-            };
-        }
-        else {
-            on_submit_unrolled = on_submit;
-        }
 
-        // If on_submit hook is not async, wrap it in an async func
-        let fin_on_submit_hook;
-        if (on_submit_unrolled.hook.constructor.name == "AsyncFunction") {
-            fin_on_submit_hook = on_submit_unrolled.hook;
-        }
-        else {
-            fin_on_submit_hook = async function (annotations) {
-                return on_submit_unrolled.hook(annotations);
-            };
-        }
+        // if (Array.isArray(submit_buttons)) {
+        //     this.buttons
+        // }
+
+
+        // // Unroll submit button
+        // let on_submit_unrolled;
+        // if (typeof submit_buttons == "function") {
+        //     on_submit_unrolled = {
+        //         name: "Submit",
+        //         hook: submit_buttons
+        //     };
+        // }
+        // else {
+        //     on_submit_unrolled = submit_buttons;
+        // }
+
+        // // If on_submit hook is not async, wrap it in an async func
+        // let fin_on_submit_hook;
+        // if (on_submit_unrolled.hook.constructor.name == "AsyncFunction") {
+        //     fin_on_submit_hook = on_submit_unrolled.hook;
+        // }
+        // else {
+        //     fin_on_submit_hook = async function (annotations) {
+        //         return on_submit_unrolled.hook(annotations);
+        //     };
+        // }
+
+        // this.submit_buttons1 = on_submit_unrolled
 
         // TODO 
         // Allow for importing spacing data -- a measure tool would be nice too
@@ -1464,9 +1471,10 @@ export class ULabel {
             "edit_handle_size": 30,
 
             // Behavior on special interactions
-            "done_callback": fin_on_submit_hook,
-            "done_button": on_submit_unrolled.name,
+            // "done_callback": fin_on_submit_hook,
+            // "done_button": on_submit_unrolled.name,
             "instructions_url": instructions_url,
+            "submit_buttons": submit_buttons,
 
             // ID Dialog config
             "cl_opacity": 0.4,

--- a/src/index.js
+++ b/src/index.js
@@ -3089,19 +3089,19 @@ export class ULabel {
     // Action Stream Events
 
     set_saved(saved, in_progress = false) {
-        if (saved) {
-            $("#" + this.config["container_id"] + " a#submit-button").removeAttr("href");
-            $("#" + this.config["container_id"] + " a#submit-button").html(this.config["done_button"]);
-        }
-        else {
-            $("#" + this.config["container_id"] + " a#submit-button").attr("href", "#");
-            if (in_progress) {
-                $("#" + this.config["container_id"] + " a#submit-button").html(BUTTON_LOADER_HTML);
-            }
-            else {
-                $("#" + this.config["container_id"] + " a#submit-button").html(this.config["done_button"]);
-            }
-        }
+        // if (saved) {
+        //     $("#" + this.config["container_id"] + " a#submit-button").removeAttr("href");
+        //     $("#" + this.config["container_id"] + " a#submit-button").html(this.config["done_button"]);
+        // }
+        // else {
+        //     $("#" + this.config["container_id"] + " a#submit-button").attr("href", "#");
+        //     if (in_progress) {
+        //         $("#" + this.config["container_id"] + " a#submit-button").html(BUTTON_LOADER_HTML);
+        //     }
+        //     else {
+        //         $("#" + this.config["container_id"] + " a#submit-button").html(this.config["done_button"]);
+        //     }
+        // }
         this.state["edited"] = !saved;
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -312,10 +312,6 @@ export class ULabel {
 
         // Append but don't wait
         $("#" + sp_id + " .toolbox_inner_cls .mode-selection").append(md_buttons.join("<!-- -->"));
-        // TODO noconflict
-        // $("#" + sp_id + " .toolbox_inner_cls").append(`
-        //     <a id="submit-button" href="#">${ul.config["done_button"]}</a>
-        // `);
 
         // Show current mode label
         ul.show_annotation_mode();
@@ -1043,7 +1039,7 @@ export class ULabel {
                 )
             ) {
                 keypress_event.preventDefault();
-                $("a#submit-button").trigger("click");
+                $(".submit-button")[0].click(); // Click the first submit button
             }
             else if (keypress_event.key == "l") {
                 // console.log("Listing annotations using the \"l\" key has been deprecated.");

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -834,17 +834,20 @@ var SubmitButtons = /** @class */ (function (_super) {
         }
         var _loop_1 = function (idx) {
             // Create a unique event listener for each submit button in the submit buttons array.
-            $(document).on("click", "#" + this_1.submit_buttons[idx].name.replaceLowerConcat(" ", "-"), function () { return __awaiter(_this, void 0, void 0, function () {
-                var button, animation, submit_payload, stkey, i;
+            $(document).on("click", "#" + this_1.submit_buttons[idx].name.replaceLowerConcat(" ", "-"), function (e) { return __awaiter(_this, void 0, void 0, function () {
+                var button, submit_button_elements, i, animation, submit_payload, stkey, i, i;
                 return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             button = document.getElementById(this.submit_buttons[idx].name.replaceLowerConcat(" ", "-"));
-                            console.log(button);
-                            // Set the button to disabled until we're done processing the previous click
-                            button.disabled = true;
+                            submit_button_elements = Array.from(document.getElementsByClassName("submit-button"));
+                            // Make all the buttons look disabled
+                            for (i in submit_button_elements) {
+                                submit_button_elements[i].disabled = true;
+                                submit_button_elements[i].style.filter = "opacity(0.7)";
+                            }
+                            // Give the clicked button a loading animation
                             button.innerText = "";
-                            button.style.filter = "opacity(0.7)";
                             animation = document.createElement("div");
                             animation.className = "lds-dual-ring";
                             button.appendChild(animation);
@@ -863,10 +866,13 @@ var SubmitButtons = /** @class */ (function (_super) {
                             return [4 /*yield*/, this.submit_buttons[idx].hook(submit_payload)];
                         case 1:
                             _a.sent();
-                            // Set the button back to its initial state
-                            button.disabled = false;
+                            // Give the button back its name
                             button.innerText = this.submit_buttons[idx].name;
-                            button.style.filter = "opacity(1)";
+                            // Re-enable the buttons
+                            for (i in submit_button_elements) {
+                                submit_button_elements[i].disabled = false;
+                                submit_button_elements[i].style.filter = "opacity(1)";
+                            }
                             return [2 /*return*/];
                     }
                 });

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -823,7 +823,15 @@ var SubmitButtons = /** @class */ (function (_super) {
     __extends(SubmitButtons, _super);
     function SubmitButtons(ulabel) {
         var _this = _super.call(this) || this;
+        // Grab the submit buttons from ulabel
         _this.submit_buttons = ulabel.config.submit_buttons;
+        // For legacy reasons submit_buttons may be a function, in that case convert it to the right format
+        if (typeof _this.submit_buttons == "function") {
+            _this.submit_buttons = [{
+                    "name": "Submit",
+                    "hook": _this.submit_buttons
+                }];
+        }
         var _loop_1 = function (idx) {
             // Create a unique event listener for each submit button in the submit buttons array.
             $(document).on("click", "#" + this_1.submit_buttons[idx].name.replaceLowerConcat(" ", "-"), function () { return __awaiter(_this, void 0, void 0, function () {

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -872,7 +872,7 @@ var SubmitButtons = /** @class */ (function (_super) {
                 // If no color provided use hard coded default
                 button_color = "rgba(255, 166, 0, 0.739)";
             }
-            toolboxitem_html += "\n            <button \n            id=\"".concat(this.submit_buttons[idx].name.replaceLowerConcat(" ", "-"), "\" \n            class=\"submit-button\" \n            style=\"\n                background-color: ").concat(button_color, "; \n                display: block;\n                margin-left: auto;\n                margin-right: auto;\n                margin-top: 0.5em;\n                margin-bottom: 0.5em;\n                padding: 2em;\n            \">\n                ").concat(this.submit_buttons[idx].name, "\n            </button>\n            ");
+            toolboxitem_html += "\n            <button \n            id=\"".concat(this.submit_buttons[idx].name.replaceLowerConcat(" ", "-"), "\" \n            class=\"submit-button\" \n            style=\"\n                display: block;\n                width: 6em;\n                font-size: 1.5em;\n                color: white;\n                background-color: ").concat(button_color, "; \n                margin-left: auto;\n                margin-right: auto;\n                margin-top: 0.5em;\n                margin-bottom: 0.5em;\n                padding: 1em;\n                border: 1px solid ").concat(button_color, ";\n                border-radius: 0.5em;\n            \">\n                ").concat(this.submit_buttons[idx].name, "\n            </button>\n            ");
         }
         return toolboxitem_html;
     };

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -15,7 +15,7 @@ var __extends = (this && this.__extends) || (function () {
     };
 })();
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.KeypointSliderItem = exports.RecolorActiveItem = exports.AnnotationResizeItem = exports.ClassCounterToolboxItem = exports.AnnotationIDToolboxItem = exports.ZoomPanToolboxItem = exports.ModeSelectionToolboxItem = exports.ToolboxItem = exports.ToolboxTab = exports.Toolbox = void 0;
+exports.SubmitButtons = exports.KeypointSliderItem = exports.RecolorActiveItem = exports.AnnotationResizeItem = exports.ClassCounterToolboxItem = exports.AnnotationIDToolboxItem = exports.ZoomPanToolboxItem = exports.ModeSelectionToolboxItem = exports.ToolboxItem = exports.ToolboxTab = exports.Toolbox = void 0;
 var __1 = require("..");
 var configuration_1 = require("./configuration");
 var toolboxDividerDiv = "<div class=toolbox-divider></div>";
@@ -783,6 +783,31 @@ var KeypointSliderItem = /** @class */ (function (_super) {
     return KeypointSliderItem;
 }(ToolboxItem));
 exports.KeypointSliderItem = KeypointSliderItem;
+var SubmitButtons = /** @class */ (function (_super) {
+    __extends(SubmitButtons, _super);
+    function SubmitButtons(sumbit_buttons) {
+        var _this = _super.call(this) || this;
+        _this.submit_buttons = sumbit_buttons;
+        return _this;
+    }
+    SubmitButtons.prototype.get_html = function () {
+        var toolboxitem_html = "";
+        for (var idx in this.submit_buttons) {
+            var button_color = void 0;
+            if (this.submit_buttons[idx].color !== undefined) {
+                button_color = this.submit_buttons[idx].color;
+            }
+            else {
+                // If no color provided use hard coded default
+                button_color = "rgba(255, 166, 0, 0.739)";
+            }
+            toolboxitem_html += "\n            <button onclick=\"".concat(this.submit_buttons[idx].hook, "\" background-color=\"").concat(button_color, "\">\n                ").concat(this.submit_buttons[idx].name, "\n            </button>\n            ");
+        }
+        return toolboxitem_html;
+    };
+    return SubmitButtons;
+}(ToolboxItem));
+exports.SubmitButtons = SubmitButtons;
 // export class WholeImageClassifierToolboxTab extends ToolboxItem {
 //     constructor() {
 //         super(

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -14,6 +14,42 @@ var __extends = (this && this.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SubmitButtons = exports.KeypointSliderItem = exports.RecolorActiveItem = exports.AnnotationResizeItem = exports.ClassCounterToolboxItem = exports.AnnotationIDToolboxItem = exports.ZoomPanToolboxItem = exports.ModeSelectionToolboxItem = exports.ToolboxItem = exports.ToolboxTab = exports.Toolbox = void 0;
 var __1 = require("..");
@@ -785,14 +821,49 @@ var KeypointSliderItem = /** @class */ (function (_super) {
 exports.KeypointSliderItem = KeypointSliderItem;
 var SubmitButtons = /** @class */ (function (_super) {
     __extends(SubmitButtons, _super);
-    function SubmitButtons(sumbit_buttons) {
+    function SubmitButtons(ulabel) {
         var _this = _super.call(this) || this;
-        _this.submit_buttons = sumbit_buttons;
+        _this.click = "clicked";
+        _this.submit_buttons = ulabel.config.submit_buttons;
+        console.log(_this.submit_buttons);
+        console.log(_this.my_function);
+        var _loop_1 = function (idx) {
+            $(document).on("click", "#" + this_1.submit_buttons[idx].name.replaceLowerConcat(" ", "-"), function () { return __awaiter(_this, void 0, void 0, function () {
+                var submit_payload, stkey, i;
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0:
+                            submit_payload = {
+                                "task_meta": ulabel.config["task_meta"],
+                                "annotations": {}
+                            };
+                            // Loop through all of the subtasks
+                            for (stkey in ulabel.subtasks) {
+                                submit_payload["annotations"][stkey] = [];
+                                // Add all of the annotations in that subtask
+                                for (i = 0; i < ulabel.subtasks[stkey]["annotations"]["ordering"].length; i++) {
+                                    submit_payload["annotations"][stkey].push(ulabel.subtasks[stkey]["annotations"]["access"][ulabel.subtasks[stkey]["annotations"]["ordering"][i]]);
+                                }
+                            }
+                            return [4 /*yield*/, this.submit_buttons[idx].hook(submit_payload)];
+                        case 1: return [2 /*return*/, _a.sent()];
+                    }
+                });
+            }); });
+        };
+        var this_1 = this;
+        for (var idx in _this.submit_buttons) {
+            _loop_1(idx);
+        }
         return _this;
     }
+    SubmitButtons.prototype.my_function = function () {
+        this.button_holder_name;
+    };
     SubmitButtons.prototype.get_html = function () {
         var toolboxitem_html = "";
         for (var idx in this.submit_buttons) {
+            console.log("inside submit button creator", idx);
             var button_color = void 0;
             if (this.submit_buttons[idx].color !== undefined) {
                 button_color = this.submit_buttons[idx].color;
@@ -801,7 +872,7 @@ var SubmitButtons = /** @class */ (function (_super) {
                 // If no color provided use hard coded default
                 button_color = "rgba(255, 166, 0, 0.739)";
             }
-            toolboxitem_html += "\n            <button onclick=\"".concat(this.submit_buttons[idx].hook, "\" background-color=\"").concat(button_color, "\">\n                ").concat(this.submit_buttons[idx].name, "\n            </button>\n            ");
+            toolboxitem_html += "\n            <button \n            id=\"".concat(this.submit_buttons[idx].name.replaceLowerConcat(" ", "-"), "\" \n            class=\"submit-button\" \n            style=\"\n                background-color: ").concat(button_color, "; \n                display: block;\n                margin-left: auto;\n                margin-right: auto;\n                margin-top: 0.5em;\n                margin-bottom: 0.5em;\n                padding: 2em;\n            \">\n                ").concat(this.submit_buttons[idx].name, "\n            </button>\n            ");
         }
         return toolboxitem_html;
     };

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -835,7 +835,7 @@ var SubmitButtons = /** @class */ (function (_super) {
         var _loop_1 = function (idx) {
             // Create a unique event listener for each submit button in the submit buttons array.
             $(document).on("click", "#" + this_1.submit_buttons[idx].name.replaceLowerConcat(" ", "-"), function () { return __awaiter(_this, void 0, void 0, function () {
-                var button, submit_payload, stkey, i;
+                var button, animation, submit_payload, stkey, i;
                 return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
@@ -843,7 +843,11 @@ var SubmitButtons = /** @class */ (function (_super) {
                             console.log(button);
                             // Set the button to disabled until we're done processing the previous click
                             button.disabled = true;
-                            button.innerText = "( )";
+                            button.innerText = "";
+                            button.style.filter = "opacity(0.7)";
+                            animation = document.createElement("div");
+                            animation.className = "lds-dual-ring";
+                            button.appendChild(animation);
                             submit_payload = {
                                 "task_meta": ulabel.config["task_meta"],
                                 "annotations": {}
@@ -862,6 +866,7 @@ var SubmitButtons = /** @class */ (function (_super) {
                             // Set the button back to its initial state
                             button.disabled = false;
                             button.innerText = this.submit_buttons[idx].name;
+                            button.style.filter = "opacity(1)";
                             return [2 /*return*/];
                     }
                 });
@@ -884,7 +889,7 @@ var SubmitButtons = /** @class */ (function (_super) {
                 // If no color provided use hard coded default
                 button_color = "rgba(255, 166, 0, 0.739)";
             }
-            toolboxitem_html += "\n            <button \n            id=\"".concat(this.submit_buttons[idx].name.replaceLowerConcat(" ", "-"), "\" \n            class=\"submit-button\" \n            style=\"\n                display: block;\n                width: 6em;\n                font-size: 1.5em;\n                color: white;\n                background-color: ").concat(button_color, "; \n                margin-left: auto;\n                margin-right: auto;\n                margin-top: 0.5em;\n                margin-bottom: 0.5em;\n                padding: 1em;\n                border: 1px solid ").concat(button_color, ";\n                border-radius: 0.5em;\n                cursor: pointer;\n            \">\n                ").concat(this.submit_buttons[idx].name, "\n            </button>\n            ");
+            toolboxitem_html += "\n            <button \n            id=\"".concat(this.submit_buttons[idx].name.replaceLowerConcat(" ", "-"), "\" \n            class=\"submit-button\" \n            style=\"\n                display: block;\n                height: 1.2em;\n                width: 6em;\n                font-size: 1.5em;\n                color: white;\n                background-color: ").concat(button_color, "; \n                margin-left: auto;\n                margin-right: auto;\n                margin-top: 0.5em;\n                margin-bottom: 0.5em;\n                padding: 1em;\n                border: 1px solid ").concat(button_color, ";\n                border-radius: 0.5em;\n                cursor: pointer;\n            \">\n                ").concat(this.submit_buttons[idx].name, "\n            </button>\n            ");
         }
         return toolboxitem_html;
     };

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -827,10 +827,15 @@ var SubmitButtons = /** @class */ (function (_super) {
         var _loop_1 = function (idx) {
             // Create a unique event listener for each submit button in the submit buttons array.
             $(document).on("click", "#" + this_1.submit_buttons[idx].name.replaceLowerConcat(" ", "-"), function () { return __awaiter(_this, void 0, void 0, function () {
-                var submit_payload, stkey, i;
+                var button, submit_payload, stkey, i;
                 return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
+                            button = document.getElementById(this.submit_buttons[idx].name.replaceLowerConcat(" ", "-"));
+                            console.log(button);
+                            // Set the button to disabled until we're done processing the previous click
+                            button.disabled = true;
+                            button.innerText = "( )";
                             submit_payload = {
                                 "task_meta": ulabel.config["task_meta"],
                                 "annotations": {}
@@ -846,6 +851,9 @@ var SubmitButtons = /** @class */ (function (_super) {
                             return [4 /*yield*/, this.submit_buttons[idx].hook(submit_payload)];
                         case 1:
                             _a.sent();
+                            // Set the button back to its initial state
+                            button.disabled = false;
+                            button.innerText = this.submit_buttons[idx].name;
                             return [2 /*return*/];
                     }
                 });

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -823,11 +823,9 @@ var SubmitButtons = /** @class */ (function (_super) {
     __extends(SubmitButtons, _super);
     function SubmitButtons(ulabel) {
         var _this = _super.call(this) || this;
-        _this.click = "clicked";
         _this.submit_buttons = ulabel.config.submit_buttons;
-        console.log(_this.submit_buttons);
-        console.log(_this.my_function);
         var _loop_1 = function (idx) {
+            // Create a unique event listener for each submit button in the submit buttons array.
             $(document).on("click", "#" + this_1.submit_buttons[idx].name.replaceLowerConcat(" ", "-"), function () { return __awaiter(_this, void 0, void 0, function () {
                 var submit_payload, stkey, i;
                 return __generator(this, function (_a) {
@@ -846,7 +844,9 @@ var SubmitButtons = /** @class */ (function (_super) {
                                 }
                             }
                             return [4 /*yield*/, this.submit_buttons[idx].hook(submit_payload)];
-                        case 1: return [2 /*return*/, _a.sent()];
+                        case 1:
+                            _a.sent();
+                            return [2 /*return*/];
                     }
                 });
             }); });
@@ -857,13 +857,9 @@ var SubmitButtons = /** @class */ (function (_super) {
         }
         return _this;
     }
-    SubmitButtons.prototype.my_function = function () {
-        this.button_holder_name;
-    };
     SubmitButtons.prototype.get_html = function () {
         var toolboxitem_html = "";
         for (var idx in this.submit_buttons) {
-            console.log("inside submit button creator", idx);
             var button_color = void 0;
             if (this.submit_buttons[idx].color !== undefined) {
                 button_color = this.submit_buttons[idx].color;
@@ -872,7 +868,7 @@ var SubmitButtons = /** @class */ (function (_super) {
                 // If no color provided use hard coded default
                 button_color = "rgba(255, 166, 0, 0.739)";
             }
-            toolboxitem_html += "\n            <button \n            id=\"".concat(this.submit_buttons[idx].name.replaceLowerConcat(" ", "-"), "\" \n            class=\"submit-button\" \n            style=\"\n                display: block;\n                width: 6em;\n                font-size: 1.5em;\n                color: white;\n                background-color: ").concat(button_color, "; \n                margin-left: auto;\n                margin-right: auto;\n                margin-top: 0.5em;\n                margin-bottom: 0.5em;\n                padding: 1em;\n                border: 1px solid ").concat(button_color, ";\n                border-radius: 0.5em;\n            \">\n                ").concat(this.submit_buttons[idx].name, "\n            </button>\n            ");
+            toolboxitem_html += "\n            <button \n            id=\"".concat(this.submit_buttons[idx].name.replaceLowerConcat(" ", "-"), "\" \n            class=\"submit-button\" \n            style=\"\n                display: block;\n                width: 6em;\n                font-size: 1.5em;\n                color: white;\n                background-color: ").concat(button_color, "; \n                margin-left: auto;\n                margin-right: auto;\n                margin-top: 0.5em;\n                margin-bottom: 0.5em;\n                padding: 1em;\n                border: 1px solid ").concat(button_color, ";\n                border-radius: 0.5em;\n                cursor: pointer;\n            \">\n                ").concat(this.submit_buttons[idx].name, "\n            </button>\n            ");
         }
         return toolboxitem_html;
     };

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -1050,6 +1050,37 @@ export class KeypointSliderItem extends ToolboxItem {
     }
 }
 
+export class SubmitButtons extends ToolboxItem {
+    private submit_buttons: {name: string, hook: Function, color?: string}[]
+
+    constructor(sumbit_buttons: {name: string, hook: Function, color?: string}[]) {
+        super();
+        this.submit_buttons = sumbit_buttons
+    }
+
+    get_html(): string {
+        let toolboxitem_html = ``
+        for (let idx in this.submit_buttons) {
+
+            let button_color
+            if (this.submit_buttons[idx].color !== undefined) {
+                button_color = this.submit_buttons[idx].color
+            } else {
+                // If no color provided use hard coded default
+                button_color = "rgba(255, 166, 0, 0.739)"
+            }
+
+            toolboxitem_html += `
+            <button onclick="${this.submit_buttons[idx].hook}" background-color="${button_color}">
+                ${this.submit_buttons[idx].name}
+            </button>
+            `
+        }
+        return toolboxitem_html
+        
+    }
+}
+
 // export class WholeImageClassifierToolboxTab extends ToolboxItem {
 //     constructor() {
 //         super(

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -1053,20 +1053,15 @@ export class KeypointSliderItem extends ToolboxItem {
 
 export class SubmitButtons extends ToolboxItem {
     private submit_buttons: {name: string, hook: Function, color?: string}[];
-    private button_holder_name: string;
-    private click: string = "clicked"
 
     constructor(ulabel: ULabel) {
         super();
     
         this.submit_buttons = ulabel.config.submit_buttons
-        console.log(this.submit_buttons)
-        
-        
-        console.log(this.my_function)
 
         for (let idx in this.submit_buttons) {
-            
+
+            // Create a unique event listener for each submit button in the submit buttons array.
             $(document).on("click", "#" + this.submit_buttons[idx].name.replaceLowerConcat(" ", "-"), async () => {
                 // Create the submit payload
                 let submit_payload = {
@@ -1088,20 +1083,15 @@ export class SubmitButtons extends ToolboxItem {
                     }
                 }
                 
-                return await this.submit_buttons[idx].hook(submit_payload)
+                await this.submit_buttons[idx].hook(submit_payload)
             })
         }
-    }
-
-    my_function() {
-        this.button_holder_name
     }
 
     get_html(): string {
         let toolboxitem_html = ``
 
         for (let idx in this.submit_buttons) {
-            console.log("inside submit button creator", idx)
 
             let button_color
             if (this.submit_buttons[idx].color !== undefined) {
@@ -1128,6 +1118,7 @@ export class SubmitButtons extends ToolboxItem {
                 padding: 1em;
                 border: 1px solid ${button_color};
                 border-radius: 0.5em;
+                cursor: pointer;
             ">
                 ${this.submit_buttons[idx].name}
             </button>

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -1116,13 +1116,18 @@ export class SubmitButtons extends ToolboxItem {
             id="${this.submit_buttons[idx].name.replaceLowerConcat(" ", "-")}" 
             class="submit-button" 
             style="
-                background-color: ${button_color}; 
                 display: block;
+                width: 6em;
+                font-size: 1.5em;
+                color: white;
+                background-color: ${button_color}; 
                 margin-left: auto;
                 margin-right: auto;
                 margin-top: 0.5em;
                 margin-bottom: 0.5em;
-                padding: 2em;
+                padding: 1em;
+                border: 1px solid ${button_color};
+                border-radius: 0.5em;
             ">
                 ${this.submit_buttons[idx].name}
             </button>

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -1063,6 +1063,14 @@ export class SubmitButtons extends ToolboxItem {
 
             // Create a unique event listener for each submit button in the submit buttons array.
             $(document).on("click", "#" + this.submit_buttons[idx].name.replaceLowerConcat(" ", "-"), async () => {
+                // Grab the button
+                const button: HTMLButtonElement = <HTMLButtonElement> document.getElementById(this.submit_buttons[idx].name.replaceLowerConcat(" ", "-"));
+                console.log(button)
+                
+                // Set the button to disabled until we're done processing the previous click
+                button.disabled = true;
+                button.innerText = "( )";
+
                 // Create the submit payload
                 let submit_payload = {
                     "task_meta": ulabel.config["task_meta"],
@@ -1083,7 +1091,11 @@ export class SubmitButtons extends ToolboxItem {
                     }
                 }
                 
-                await this.submit_buttons[idx].hook(submit_payload)
+                await this.submit_buttons[idx].hook(submit_payload);
+
+                // Set the button back to its initial state
+                button.disabled = false;
+                button.innerText = this.submit_buttons[idx].name;
             })
         }
     }

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -1078,7 +1078,12 @@ export class SubmitButtons extends ToolboxItem {
                 
                 // Set the button to disabled until we're done processing the previous click
                 button.disabled = true;
-                button.innerText = "( )";
+                button.innerText = "";
+                button.style.filter = "opacity(0.7)";
+
+                let animation = document.createElement("div");
+                animation.className = "lds-dual-ring";
+                button.appendChild(animation);
 
                 // Create the submit payload
                 let submit_payload = {
@@ -1105,6 +1110,7 @@ export class SubmitButtons extends ToolboxItem {
                 // Set the button back to its initial state
                 button.disabled = false;
                 button.innerText = this.submit_buttons[idx].name;
+                button.style.filter = "opacity(1)";
             })
         }
     }
@@ -1128,6 +1134,7 @@ export class SubmitButtons extends ToolboxItem {
             class="submit-button" 
             style="
                 display: block;
+                height: 1.2em;
                 width: 6em;
                 font-size: 1.5em;
                 color: white;

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -1071,16 +1071,21 @@ export class SubmitButtons extends ToolboxItem {
         for (let idx in this.submit_buttons) {
 
             // Create a unique event listener for each submit button in the submit buttons array.
-            $(document).on("click", "#" + this.submit_buttons[idx].name.replaceLowerConcat(" ", "-"), async () => {
+            $(document).on("click", "#" + this.submit_buttons[idx].name.replaceLowerConcat(" ", "-"), async (e) => {
                 // Grab the button
                 const button: HTMLButtonElement = <HTMLButtonElement> document.getElementById(this.submit_buttons[idx].name.replaceLowerConcat(" ", "-"));
-                console.log(button)
                 
-                // Set the button to disabled until we're done processing the previous click
-                button.disabled = true;
-                button.innerText = "";
-                button.style.filter = "opacity(0.7)";
+                // Grab all of the submit buttons
+                let submit_button_elements = <HTMLButtonElement[]> Array.from(document.getElementsByClassName("submit-button"));
+                
+                // Make all the buttons look disabled
+                for (let i in submit_button_elements) {
+                    submit_button_elements[i].disabled = true;
+                    submit_button_elements[i].style.filter = "opacity(0.7)";
+                }
 
+                // Give the clicked button a loading animation
+                button.innerText = "";
                 let animation = document.createElement("div");
                 animation.className = "lds-dual-ring";
                 button.appendChild(animation);
@@ -1107,10 +1112,14 @@ export class SubmitButtons extends ToolboxItem {
                 
                 await this.submit_buttons[idx].hook(submit_payload);
 
-                // Set the button back to its initial state
-                button.disabled = false;
+                // Give the button back its name
                 button.innerText = this.submit_buttons[idx].name;
-                button.style.filter = "opacity(1)";
+
+                // Re-enable the buttons
+                for (let i in submit_button_elements) {
+                    submit_button_elements[i].disabled = false;
+                    submit_button_elements[i].style.filter = "opacity(1)";
+                }
             })
         }
     }

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -1052,12 +1052,21 @@ export class KeypointSliderItem extends ToolboxItem {
 }
 
 export class SubmitButtons extends ToolboxItem {
-    private submit_buttons: {name: string, hook: Function, color?: string}[];
+    private submit_buttons: {name: string, hook: Function, color?: string}[] | Function;
 
     constructor(ulabel: ULabel) {
         super();
     
+        // Grab the submit buttons from ulabel
         this.submit_buttons = ulabel.config.submit_buttons
+
+        // For legacy reasons submit_buttons may be a function, in that case convert it to the right format
+        if (typeof this.submit_buttons == "function") {
+            this.submit_buttons = [{
+                "name": "Submit",
+                "hook": this.submit_buttons
+            }]
+        }
 
         for (let idx in this.submit_buttons) {
 


### PR DESCRIPTION
# Add support for an arbitrary quantity of submit buttons

## Description

This changes the submit button by turning it into a toolbox item. Currently the submit button is created by after we create the toolbox, then we create the submit button and append its html to the toolbox. I was asked to add support for multiple submit buttons, so it made sense to update it and make it a toolbox item while I was at it. 

## PR Checklist

- [ ] Merged latest main
- [ ] Version number in `package.json` has been bumped since last release
- [ ] Version numbers match between package `package.json` and `src/version.js`
- [ ] Ran `npm install` and `npm run build` AFTER bumping the version number
- [ ] Updated documentation if necessary (currently just in `api_spec.md`)
- [ ] Added changes to `changelog.md`

## Breaking API Changes

Removed the "submit-button" id from the submit button and now all submit buttons have a "submit-button" class. This may break something in our py-mfstand frontend.
