### PR TITLE
Add support for toolbox order to be passed into ulabel constructor

### DIFF
--- a/dist/ulabel.js
+++ b/dist/ulabel.js
@@ -14799,7 +14799,7 @@ class ULabel {
         return toolbox_instance_list
     }
 
-    static prep_window_html(ul) {
+    static prep_window_html(ul, toolbox_item_order = null) {
         // Bring image and annotation scaffolding in
         // TODO multi-image with spacing etc.
 
@@ -14810,7 +14810,7 @@ class ULabel {
         // const toolbox = configuration.create_toolbox();
         const toolbox = new src_toolbox.Toolbox(
             [],
-            ULabel.create_toolbox(ul)
+            ULabel.create_toolbox(ul, toolbox_item_order)
         );
 
 
@@ -15922,9 +15922,11 @@ class ULabel {
         initial_crop = null, //{top: #, left: #, height: #, width: #,}
         initial_line_size = 4,
         instructions_url = null,
-        config_data = null
+        config_data = null,
+        toolbox_order = null
     ) {
         console.log(this)
+        console.log(toolbox_order, "Toolbox order", task_meta)
         // // Unroll safe default arguments
         // if (task_meta == null) { task_meta = {}; }
         // if (annotation_meta == null) { annotation_meta = {}; }
@@ -16017,6 +16019,8 @@ class ULabel {
             this.config.modify_config(config_data)
         }
 
+        this.toolbox_order = toolbox_order;
+
 
         // Useful for the efficient redraw of nonspatial annotations
         this.tmp_nonspatial_element_ids = {};
@@ -16107,7 +16111,7 @@ class ULabel {
         that.state["current_subtask"] = Object.keys(that.subtasks)[0];
 
         // Place image element
-        ULabel.prep_window_html(this);
+        ULabel.prep_window_html(this, this.toolbox_order);
 
         // Detect night cookie
         if (ULabel.has_night_mode_cookie()) {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -2,14 +2,14 @@ import { ModeSelectionToolboxItem, ZoomPanToolboxItem, AnnotationIDToolboxItem, 
 import { get_annotation_confidence, mark_deprecated, filter_low } from "./annotation_operators";
 
 enum AllowedToolboxItem {
-    ModeSelect,
-    ZoomPan,
-    AnnotationResize,
-    AnnotationID,
-    RecolorActive,
-    ClassCounter,
-    KeypointSlider,
-    SubmitButtons
+    ModeSelect,         // 0
+    ZoomPan,            // 1
+    AnnotationResize,   // 2
+    AnnotationID,       // 3
+    RecolorActive,      // 4
+    ClassCounter,       // 5
+    KeypointSlider,     // 6
+    SubmitButtons       // 7
 }
 
 export class Configuration {

--- a/src/index.js
+++ b/src/index.js
@@ -269,7 +269,7 @@ export class ULabel {
         return toolbox_instance_list
     }
 
-    static prep_window_html(ul) {
+    static prep_window_html(ul, toolbox_item_order = null) {
         // Bring image and annotation scaffolding in
         // TODO multi-image with spacing etc.
 
@@ -280,7 +280,7 @@ export class ULabel {
         // const toolbox = configuration.create_toolbox();
         const toolbox = new Toolbox(
             [],
-            ULabel.create_toolbox(ul)
+            ULabel.create_toolbox(ul, toolbox_item_order)
         );
 
 
@@ -1392,9 +1392,11 @@ export class ULabel {
         initial_crop = null, //{top: #, left: #, height: #, width: #,}
         initial_line_size = 4,
         instructions_url = null,
-        config_data = null
+        config_data = null,
+        toolbox_order = null
     ) {
         console.log(this)
+        console.log(toolbox_order, "Toolbox order", task_meta)
         // // Unroll safe default arguments
         // if (task_meta == null) { task_meta = {}; }
         // if (annotation_meta == null) { annotation_meta = {}; }
@@ -1487,6 +1489,8 @@ export class ULabel {
             this.config.modify_config(config_data)
         }
 
+        this.toolbox_order = toolbox_order;
+
 
         // Useful for the efficient redraw of nonspatial annotations
         this.tmp_nonspatial_element_ids = {};
@@ -1577,7 +1581,7 @@ export class ULabel {
         that.state["current_subtask"] = Object.keys(that.subtasks)[0];
 
         // Place image element
-        ULabel.prep_window_html(this);
+        ULabel.prep_window_html(this, this.toolbox_order);
 
         // Detect night cookie
         if (ULabel.has_night_mode_cookie()) {


### PR DESCRIPTION
# Add ability to pass in toolbox order to ulabel constructor

## Description

Add ability to pass in toolbox order to ulabel constructor. The create toolbox was created to allow a custom toolbox order to be passed in, we just never allowed you to pass one into the ulabel constructor

## PR Checklist

- [ ] Merged latest main
- [ ] Version number in `package.json` has been bumped since last release
- [ ] Version numbers match between package `package.json` and `src/version.js`
- [ ] Ran `npm install` and `npm run build` AFTER bumping the version number
- [ ] Updated documentation if necessary (currently just in `api_spec.md`)
- [ ] Added changes to `changelog.md`

## Breaking API Changes

none