### PR TITLE
Add README section on react integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ An API spec can be found [here](https://github.com/SenteraLLC/ulabel/blob/main/a
 </html>
 ```
 
+### Integrating in a React Project
+
+See [ulabel-react-demo](https://github.com/joshua-dean/ulabel-react-demo/tree/main)
+for an example of how to integrate ULabel into a React project.
+
 ## Development
 
 The recommended way to develop new features is to use the tool as if you were running the demo. For testing new API features, you can create a new HTML file in `demo/`. The server in `demo.js` runs a static server from `demo/` so it will be served at `localhost:8080/<new-file>.html` automatically.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ An API spec can be found [here](https://github.com/SenteraLLC/ulabel/blob/main/a
 
 ### Integrating in a React Project
 
-See [ulabel-react-demo](https://github.com/joshua-dean/ulabel-react-demo/tree/main)
+See [ulabel-react-demo](https://github.com/joshua-dean/ulabel-react-demo/)
 for an example of how to integrate ULabel into a React project.
 
 ## Development


### PR DESCRIPTION
# Add react demo to README
## Description
Adds a section to the README linking to [ulabel-react-demo](https://github.com/joshua-dean/ulabel-react-demo/),
a project demonstrating integration of ULabel into a React project.

Closes #42 and closes #51. Open new issues if you have a specific use case not covered by the demo.

## PR Checklist

- [X] Merged latest main
- [ ] ~Version number in `package.json` has been bumped since last release~
- [ ] ~Version numbers match between package `package.json` and `src/version.js`~
- [ ] ~Ran `npm install` and `npm run build` AFTER bumping the version number~
- [X] Updated documentation if necessary (currently just in `api_spec.md`)
- [ ] ~Added changes to `changelog.md`~

## Breaking API Changes
no API changes
