### PR TITLE
Fix/189 misc quirks

### DIFF
--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -2,6 +2,8 @@
  * ULabel cookie utilities.
  */
 
+import { ULabelSubtask } from "./subtask";
+
 export abstract class NightModeCookie {
     /**
      * The name of the cookie that stores the night mode preference.
@@ -41,5 +43,59 @@ export abstract class NightModeCookie {
             "expires=Thu, 01 Jan 1970 00:00:00 UTC",
             "path=/",
         ].join(";");
+    }
+}
+
+/**
+ * Cookie utilities for tracking annotation display size.
+ */
+export abstract class AnnotationSizeCookie {
+    /**
+     * Produce the name of the cookie for a given subtask.
+     * Swaps spaces for underscores and lowercases the name.
+     *
+     * @param subtask ULabelSubtask to generate the cookie name for.
+     */
+    private static cooke_name(subtask: ULabelSubtask): string {
+        const subtask_name = subtask.display_name.replaceLowerConcat(" ", "_");
+        return `${subtask_name}_size`;
+    }
+
+    /**
+     * Set the annotation size cookie for a given subtask.
+     *
+     * @param cookie_value Cookie value to set.
+     * @param subtask Subtask to set the cookie for.
+     */
+    public static set_size_cookie(
+        cookie_value: number,
+        subtask: ULabelSubtask,
+    ) {
+        const cookie_name = AnnotationSizeCookie.cooke_name(subtask);
+        const d = new Date();
+        d.setTime(d.getTime() + (10000 * 24 * 60 * 60 * 1000));
+
+        document.cookie = `${cookie_name}=${cookie_value};${d.toUTCString()};path=/`;
+    }
+
+    /**
+     * Retrieve the annotation size cookie for a given subtask, if it exists.
+     *
+     * @param subtask Subtask to read the cookie for.
+     * @returns The cookie value if it exists, otherwise null.
+     */
+    public static read_size_cookie(subtask: ULabelSubtask): number | null {
+        const cookie_name = AnnotationSizeCookie.cooke_name(subtask);
+        const cookie_array = document.cookie.split(";");
+
+        cookie_array.forEach((cookie) => {
+            // Trim whitespace at the beginning
+            cookie = cookie.trim();
+            if (cookie.startsWith(cookie_name)) {
+                return parseInt(cookie.split("=")[1]);
+            }
+        });
+
+        return null;
     }
 }

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -56,7 +56,7 @@ export abstract class AnnotationSizeCookie {
      *
      * @param subtask ULabelSubtask to generate the cookie name for.
      */
-    private static cooke_name(subtask: ULabelSubtask): string {
+    private static cookie_name(subtask: ULabelSubtask): string {
         const subtask_name = subtask.display_name.replaceLowerConcat(" ", "_");
         return `${subtask_name}_size`;
     }
@@ -71,30 +71,36 @@ export abstract class AnnotationSizeCookie {
         cookie_value: number,
         subtask: ULabelSubtask,
     ) {
-        const cookie_name = AnnotationSizeCookie.cooke_name(subtask);
+        const cookie_name = AnnotationSizeCookie.cookie_name(subtask);
         const d = new Date();
         d.setTime(d.getTime() + (10000 * 24 * 60 * 60 * 1000));
 
-        document.cookie = `${cookie_name}=${cookie_value};${d.toUTCString()};path=/`;
+        document.cookie = `${cookie_name}=${cookie_value};expires=${d.toUTCString()};path=/`;
     }
 
     /**
      * Retrieve the annotation size cookie for a given subtask, if it exists.
+     * Resolves NaN to null.
      *
      * @param subtask Subtask to read the cookie for.
      * @returns The cookie value if it exists, otherwise null.
      */
     public static read_size_cookie(subtask: ULabelSubtask): number | null {
-        const cookie_name = AnnotationSizeCookie.cooke_name(subtask);
+        const cookie_name = AnnotationSizeCookie.cookie_name(subtask);
+        console.log(cookie_name);
         const cookie_array = document.cookie.split(";");
 
-        cookie_array.forEach((cookie) => {
+        for (let cookie of cookie_array) {
             // Trim whitespace at the beginning
             cookie = cookie.trim();
             if (cookie.startsWith(cookie_name)) {
-                return parseInt(cookie.split("=")[1]);
+                let cookie_value = parseInt(cookie.split("=")[1]);
+                if (cookie_value === undefined || isNaN(cookie_value)) {
+                    cookie_value = null;
+                }
+                return cookie_value;
             }
-        });
+        };
 
         return null;
     }

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -24,6 +24,7 @@ import {
     get_local_storage_item,
     set_local_storage_item,
 } from "./utilities";
+import { AnnotationSizeCookie } from "./cookies";
 
 // For ResizeToolboxItem
 enum ValidResizeValues {
@@ -1171,8 +1172,8 @@ export class AnnotationResizeItem extends ToolboxItem {
         // that the annotation was saved as.
         for (const subtask in ulabel.subtasks) {
             const cached_size_property = ulabel.subtasks[subtask].display_name.replaceLowerConcat(" ", "-", "-cached-size");
-            const size_cookie = this.read_size_cookie(ulabel.subtasks[subtask]);
-            if ((size_cookie != null) && size_cookie != "NaN") {
+            const size_cookie = AnnotationSizeCookie.read_size_cookie(ulabel.subtasks[subtask]);
+            if (size_cookie != null) {
                 this.update_annotation_size(ulabel, ulabel.subtasks[subtask], Number(size_cookie));
                 this[cached_size_property] = Number(size_cookie);
             } else if (ulabel.config.default_annotation_size != undefined) {
@@ -1420,7 +1421,8 @@ export class AnnotationResizeItem extends ToolboxItem {
         }
 
         if (subtask.annotations.ordering.length > 0) {
-            this.set_size_cookie(subtask.annotations.access[subtask.annotations.ordering[0]].line_size, subtask);
+            const cst_line_size = subtask.annotations.access[subtask.annotations.ordering[0]].line_size;
+            AnnotationSizeCookie.set_size_cookie(cst_line_size, subtask);
         }
     }
 
@@ -1429,38 +1431,6 @@ export class AnnotationResizeItem extends ToolboxItem {
         for (const subtask in ulabel.subtasks) {
             this.update_annotation_size(ulabel, ulabel.subtasks[subtask], size);
         }
-    }
-
-    private set_size_cookie(cookie_value, subtask) {
-        const d = new Date();
-        d.setTime(d.getTime() + (10000 * 24 * 60 * 60 * 1000));
-
-        const subtask_name = subtask.display_name.replaceLowerConcat(" ", "_");
-
-        document.cookie = subtask_name + "_size=" + cookie_value + ";" + d.toUTCString() + ";path=/";
-    }
-
-    private read_size_cookie(subtask) {
-        const subtask_name = subtask.display_name.replaceLowerConcat(" ", "_");
-
-        const cookie_name = subtask_name + "_size=";
-
-        const cookie_array = document.cookie.split(";");
-
-        for (let i = 0; i < cookie_array.length; i++) {
-            let current_cookie = cookie_array[i];
-
-            // while there's whitespace at the front of the cookie, loop through and remove it
-            while (current_cookie.charAt(0) == " ") {
-                current_cookie = current_cookie.substring(1);
-            }
-
-            if (current_cookie.indexOf(cookie_name) == 0) {
-                return current_cookie.substring(cookie_name.length, current_cookie.length);
-            }
-        }
-
-        return null;
     }
 
     public get_html() {


### PR DESCRIPTION
# Fix misc quirks found in #175

## Description
Closes #189. Might bundle this in #202. 

Changes:
- Add `AnnotationSizeCookie` static class to manage the annotation display size
  - Previously this wasn't even working as the second field didn't contain `expires=`

## PR Checklist

- [ ] Merged latest main
- [ ] Version number in `package.json` has been bumped since last release
- [ ] Version numbers match between package `package.json` and `src/version.js`
- [ ] Ran `npm install` and `npm run build` AFTER bumping the version number
- [ ] Updated documentation if necessary (currently just in `api_spec.md`)
- [ ] Added changes to `changelog.md`

## Breaking API Changes
Annotation size cookie now actually works
