### PR TITLE
Feature/vertex delete

### DIFF
--- a/.github/tasks.md
+++ b/.github/tasks.md
@@ -6,5 +6,5 @@
   - [x] For polylines, if only one point remains in the polyline, it should delete the polyline
   - [x] For polygons, if fewer than 3 points remain in a polygon layer, the layer should be removed
 - [x] Add a test for the keybind in keybind-functionality.spec.js
-- [ ] Update the api_spec and changelog
+- [x] Update the api_spec and changelog
 

--- a/.github/tasks.md
+++ b/.github/tasks.md
@@ -1,3 +1,10 @@
 ## Tasks
-- [x] Remove the "line_size" property from ULabelAnnotation. Update the entire codebase to ensure no reference to it remains. Instead, use the line_size defined for the annotation's subtask when we need a line size for drawing the annotation.
+- [x] Read the discussion in issue [#159](https://github.com/SenteraLLC/ulabel/issues/159)
+- [x] Implement a vertex deletion keybind for polygon and polyline spatial types it should:
+  - [x] Delete the vertex when pressed when hovering over it such that the edit suggestion is showing
+  - [x] Delete the vertex when pressed when dragging/editing the vertex
+  - [x] For polylines, if only one point remains in the polyline, it should delete the polyline
+  - [x] For polygons, if fewer than 3 points remain in a polygon layer, the layer should be removed
+- [ ] Add a test for the keybind in keybind-functionality.spec.js
+- [ ] Update the api_spec and changelog
 

--- a/.github/tasks.md
+++ b/.github/tasks.md
@@ -5,6 +5,6 @@
   - [x] Delete the vertex when pressed when dragging/editing the vertex
   - [x] For polylines, if only one point remains in the polyline, it should delete the polyline
   - [x] For polygons, if fewer than 3 points remain in a polygon layer, the layer should be removed
-- [ ] Add a test for the keybind in keybind-functionality.spec.js
+- [x] Add a test for the keybind in keybind-functionality.spec.js
 - [ ] Update the api_spec and changelog
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented here.
 
 ## [unreleased]
 
+## [0.23.0] - Jan 16th, 2026
+- Add vertex deletion keybind for polygon and polyline annotations
+  - New configurable `delete_vertex_keybind` (default: `x`)
+  - Delete individual vertices by hovering over them and pressing the keybind
+  - Automatically deletes entire polyline if only 1 point remains after deletion
+  - Automatically removes polygon layer if fewer than 3 points remain after deletion
+- Fixed bug where deleting an annotation mid-edit would cause the ULabel state to be stuck in edit mode.
+
 ## [0.22.1] - Jan 13th, 2026
 - Don't draw annotations when a subtask is vanished
 - Add configurable `annotation_vanish_all_keybind`

--- a/api_spec.md
+++ b/api_spec.md
@@ -435,7 +435,7 @@ Keybind to create a point annotation at the mouse location. Default is `c`. Requ
 Keybind to delete the annotation that the mouse is hovering over. Default is `d`.
 
 ### `delete_vertex_keybind`
-Keybind to delete a vertex of a polygon or polyline annotation. The vertex must be the one currently being hovered (showing an edit suggestion) or actively being edited. For polylines, if only one point remains after deletion, the entire polyline is deleted. For polygons, if fewer than 3 points remain in a layer after deletion, that layer is removed. Default is `x`.
+Keybind to delete a vertex of a polygon or polyline annotation. The vertex must be the one currently being hovered (showing an edit suggestion) or actively being edited. For polylines, if only one point remains after deletion, the entire polyline is deleted. For polygons, if fewer than 3 points remain in a layer after deletion, that layer is removed. Default is `shift+d`.
 
 ### `keypoint_slider_default_value`
 Default value for the keypoint slider. Must be a number between 0 and 1. Default is `0`.

--- a/api_spec.md
+++ b/api_spec.md
@@ -56,6 +56,7 @@ class ULabel({
     show_full_image_keybind: string,
     create_point_annotation_keybind: string,
     delete_annotation_keybind: string,
+    delete_vertex_keybind: string,
     keypoint_slider_default_value: number,
     filter_annotations_on_load: boolean,
     switch_subtask_keybind: string,
@@ -432,6 +433,9 @@ Keybind to create a point annotation at the mouse location. Default is `c`. Requ
 
 ### `delete_annotation_keybind`
 Keybind to delete the annotation that the mouse is hovering over. Default is `d`.
+
+### `delete_vertex_keybind`
+Keybind to delete a vertex of a polygon or polyline annotation. The vertex must be the one currently being hovered (showing an edit suggestion) or actively being edited. For polylines, if only one point remains after deletion, the entire polyline is deleted. For polygons, if fewer than 3 points remain in a layer after deletion, that layer is removed. Default is `x`.
 
 ### `keypoint_slider_default_value`
 Default value for the keypoint slider. Must be a number between 0 and 1. Default is `0`.

--- a/api_spec.md
+++ b/api_spec.md
@@ -435,7 +435,7 @@ Keybind to create a point annotation at the mouse location. Default is `c`. Requ
 Keybind to delete the annotation that the mouse is hovering over. Default is `d`.
 
 ### `delete_vertex_keybind`
-Keybind to delete a vertex of a polygon or polyline annotation. The vertex must be the one currently being hovered (showing an edit suggestion) or actively being edited. For polylines, if only one point remains after deletion, the entire polyline is deleted. For polygons, if fewer than 3 points remain in a layer after deletion, that layer is removed. Default is `shift+d`.
+Keybind to delete a vertex of a polygon or polyline annotation. The vertex must be the one currently being hovered (showing an edit suggestion) or actively being edited. For polylines, if only one point remains after deletion, the entire polyline is deleted. For polygons, if fewer than 3 points remain in a layer after deletion, that layer is removed. Default is `x`.
 
 ### `keypoint_slider_default_value`
 Default value for the keypoint slider. Must be a number between 0 and 1. Default is `0`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -194,6 +194,7 @@ export type ULabelActionType = "create_nonspatial_annotation" |
     "finish_move" |
     "cancel_annotation" |
     "delete_annotation" |
+    "delete_vertex" |
     "delete_annotations_in_polygon" |
     "start_complex_polygon" |
     "merge_polygon_complex_layer" |
@@ -377,6 +378,12 @@ export class ULabel {
         redoing?: boolean,
         should_record_action?: boolean,
     ): void;
+    public delete_vertex(
+        annotation_id: string,
+        access_str: string | number | [number, number],
+        redoing?: boolean,
+        should_record_action?: boolean,
+    ): void;
     public cancel_annotation(annotation_id?: string): void;
     public assign_annotation_id(annotation_id?: string, redo_payload?: object): void;
     public create_point_annotation_at_mouse_location(): void;
@@ -414,6 +421,7 @@ export class ULabel {
     public begin_edit__undo(annotation_id: string, undo_payload: object): void;
     public begin_move__undo(annotation_id: string, undo_payload: object): void;
     public delete_annotation__undo(annotation_id: string): void;
+    public delete_vertex__undo(annotation_id: string, undo_payload: object): void;
     public cancel_annotation__undo(annotation_id: string, undo_payload: object): void;
     public assign_annotation_id__undo(annotation_id: string, undo_payload: object): void;
     public create_annotation__undo(annotation_id: string): void;
@@ -431,6 +439,7 @@ export class ULabel {
     public begin_edit__redo(annotation_id: string, redo_payload: object): void;
     public begin_move__redo(annotation_id: string, redo_payload: object): void;
     public delete_annotation__redo(annotation_id: string): void;
+    public delete_vertex__redo(annotation_id: string, redo_payload: object): void;
     public create_annotation__redo(annotation_id: string, redo_payload: object): void;
     public finish_modify_annotation__redo(annotation_id: string, redo_payload: object): void;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -234,6 +234,7 @@ export type ULabelActionCandidate = {
     point: [number, number]; // Mouse location
     spatial_type: ULabelSpatialType;
     offset?: Offset; // Optional offset for move actions
+    is_vertex?: boolean; // True if hovering over an actual vertex, false if hovering over a segment
 };
 
 export type ULabelSubtasks = { [key: string]: ULabelSubtask };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ulabel",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ulabel",
-      "version": "0.22.1",
+      "version": "0.23.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/config-inspector": "^1.3.0",
@@ -6971,9 +6971,9 @@
       "dev": true
     },
     "node_modules/h3": {
-      "version": "1.15.4",
-      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.4.tgz",
-      "integrity": "sha512-z5cFQWDffyOe4vQ9xIqNfCZdV4p//vy6fBnr8Q1AWnVZ0teurKMG66rLj++TKwKPUP3u7iMUvrvKaEUiQw2QWQ==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.5.tgz",
+      "integrity": "sha512-xEyq3rSl+dhGX2Lm0+eFQIAzlDN6Fs0EcC4f7BNUmzaRX/PTzeuM+Tr2lHB8FoXggsQIeXLj8EDVgs5ywxyxmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6982,9 +6982,9 @@
         "defu": "^6.1.4",
         "destr": "^2.0.5",
         "iron-webcrypto": "^1.2.1",
-        "node-mock-http": "^1.0.2",
+        "node-mock-http": "^1.0.4",
         "radix3": "^1.1.2",
-        "ufo": "^1.6.1",
+        "ufo": "^1.6.3",
         "uncrypto": "^0.1.3"
       }
     },
@@ -9039,9 +9039,9 @@
       "license": "MIT"
     },
     "node_modules/node-mock-http": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.3.tgz",
-      "integrity": "sha512-jN8dK25fsfnMrVsEhluUTPkBFY+6ybu7jSB1n+ri/vOGjJxU8J9CZhpSGkHXSkFjtUhbmoncG/YG9ta5Ludqog==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.4.tgz",
+      "integrity": "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -10825,9 +10825,9 @@
       }
     },
     "node_modules/ufo": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
-      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ulabel",
   "description": "An image annotation tool.",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "main": "dist/ulabel.min.js",
   "module": "dist/ulabel.min.js",
   "exports": {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -253,6 +253,10 @@ function trigger_action_listeners(
             action: on_annotation_deletion,
             undo: on_finish_annotation_spatial_modification,
         },
+        delete_vertex: {
+            action: on_finish_annotation_spatial_modification,
+            undo: on_finish_annotation_spatial_modification,
+        },
         assign_annotation_id: {
             action: on_annotation_id_change,
             undo: on_annotation_id_change,
@@ -570,6 +574,9 @@ function undo_action(ulabel: ULabel, action: ULabelAction) {
         case "delete_annotation":
             ulabel.delete_annotation__undo(action.annotation_id);
             break;
+        case "delete_vertex":
+            ulabel.delete_vertex__undo(action.annotation_id, undo_payload);
+            break;
         case "cancel_annotation":
             ulabel.cancel_annotation__undo(action.annotation_id, undo_payload);
             break;
@@ -643,6 +650,9 @@ export function redo_action(ulabel: ULabel, action: ULabelAction) {
             break;
         case "delete_annotation":
             ulabel.delete_annotation__redo(action.annotation_id);
+            break;
+        case "delete_vertex":
+            ulabel.delete_vertex__redo(action.annotation_id, redo_payload);
             break;
         case "cancel_annotation":
             ulabel.cancel_annotation(action.annotation_id);

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -198,6 +198,8 @@ export class Configuration {
 
     public delete_annotation_keybind: string = "d";
 
+    public delete_vertex_keybind: string = "x";
+
     public keypoint_slider_default_value: number;
 
     public filter_annotations_on_load: boolean = true;

--- a/src/index.js
+++ b/src/index.js
@@ -3243,6 +3243,7 @@ export class ULabel {
             access: null,
             distance: max_dist / this.get_empirical_scale(),
             point: null,
+            is_vertex: true,
         };
         if (candidates === null) {
             candidates = this.get_current_subtask()["annotations"]["ordering"];
@@ -3346,6 +3347,7 @@ export class ULabel {
             access: null,
             distance: max_dist / this.get_empirical_scale(),
             point: null,
+            is_vertex: false,
         };
         if (candidates === null) {
             candidates = this.get_current_subtask()["annotations"]["ordering"];

--- a/src/index.js
+++ b/src/index.js
@@ -3087,6 +3087,15 @@ export class ULabel {
             current_subtask["state"]["starting_complex_polygon"] = false;
         }
 
+        // Clear drag state if we're in the middle of a drag
+        if (this.drag_state["active_key"] !== null) {
+            this.drag_state["active_key"] = null;
+            this.drag_state["release_button"] = null;
+        }
+
+        // Clear edit candidate
+        current_subtask["state"]["edit_candidate"] = null;
+
         let frame = this.state["current_frame"];
         if (MODES_3D.includes(spatial_type)) {
             frame = null;
@@ -3190,6 +3199,15 @@ export class ULabel {
             current_subtask["state"]["active_id"] = null;
             current_subtask["state"]["is_in_edit"] = false;
         }
+
+        // Clear drag state if we're in the middle of a drag
+        if (this.drag_state["active_key"] !== null) {
+            this.drag_state["active_key"] = null;
+            this.drag_state["release_button"] = null;
+        }
+
+        // Clear edit candidate
+        current_subtask["state"]["edit_candidate"] = null;
 
         let frame = this.state["current_frame"];
         if (MODES_3D.includes(spatial_type)) {

--- a/src/listeners.ts
+++ b/src/listeners.ts
@@ -604,6 +604,16 @@ export function create_ulabel_listeners(
                     ulabel.delete_annotation(edit_cand.annid);
                 }
             }
+            // Check the key pressed against the delete vertex keybind in the config
+            if (event_matches_keybind(keypress_event, ulabel.config.delete_vertex_keybind)) {
+                const current_subtask = ulabel.get_current_subtask();
+                const edit_cand = current_subtask.state.edit_candidate;
+
+                // Check if we have an edit candidate
+                if (edit_cand !== null) {
+                    ulabel.delete_vertex(edit_cand.annid, edit_cand.access);
+                }
+            }
         },
     );
 

--- a/src/listeners.ts
+++ b/src/listeners.ts
@@ -609,8 +609,8 @@ export function create_ulabel_listeners(
                 const current_subtask = ulabel.get_current_subtask();
                 const edit_cand = current_subtask.state.edit_candidate;
 
-                // Check if we have an edit candidate
-                if (edit_cand !== null) {
+                // Only delete if we have an edit candidate that is an actual vertex (not a segment point)
+                if (edit_cand !== null && edit_cand.is_vertex === true) {
                     ulabel.delete_vertex(edit_cand.annid, edit_cand.access);
                 }
             }

--- a/src/toolbox_items/keybinds.ts
+++ b/src/toolbox_items/keybinds.ts
@@ -317,6 +317,14 @@ export class KeybindsToolboxItem extends ToolboxItem {
         });
 
         keybinds.push({
+            key: config.delete_vertex_keybind,
+            label: "Delete Vertex",
+            description: "Delete a vertex from polygon/polyline (hover or drag)",
+            configurable: true,
+            config_key: "delete_vertex_keybind",
+        });
+
+        keybinds.push({
             key: config.switch_subtask_keybind,
             label: "Switch Subtask",
             description: "Switch to the next subtask",

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export const ULABEL_VERSION = "0.22.1";
+export const ULABEL_VERSION = "0.23.0";

--- a/tests/testing-utils/drawing_utils.js
+++ b/tests/testing-utils/drawing_utils.js
@@ -54,7 +54,7 @@ export async function draw_point(page, position) {
 }
 
 /**
- * Draw a polyline and return its spatial payload.
+ * Draw a polygon and return its spatial payload.
  *
  * @param {Page} page
  * @param {[number, number][]} points
@@ -75,12 +75,15 @@ export async function draw_polygon(page, points) {
     await page.waitForTimeout(200);
 
     // Convert coordinates to image space
+    // Polygon spatial payload is an array of layers, where each layer has points with first/last duplicated
     return await page.evaluate((pts) => {
         const image_points = pts.map((pt) =>
             window.ulabel.get_image_aware_mouse_x_y(
                 { pageX: pt[0], pageY: pt[1] },
             ),
         );
+        // Duplicate the first point at the end to close the polygon (ulabel format)
+        image_points.push([...image_points[0]]);
         return [image_points];
     }, points);
 }


### PR DESCRIPTION
# Vertex Delete

## Description
- Closes #159 
- Add vertex deletion keybind for polygon and polyline annotations
  - New configurable `delete_vertex_keybind` (default: `x`)
  - Delete individual vertices by hovering over them and pressing the keybind
  - Automatically deletes entire polyline if only 1 point remains after deletion
  - Automatically removes polygon layer if fewer than 3 points remain after deletion
- Fixed bug where deleting an annotation mid-edit would cause the ULabel state to be stuck in edit mode.

## PR Checklist
- [x] Merged latest main
- [x] Version number in `package.json` has been bumped since last release
- [x] Version numbers match between package `package.json` and `src/version.js`
- [x] Updated documentation if necessary (currently just in `api_spec.md`)
- [x] Added changes to `changelog.md`

## Breaking API Changes
No
