### PR TITLE
Fix/type export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented here.
 
 ## [unreleased]
 
+## [0.23.1] - Mar 18th, 2026
+- Fix export of typescript types
+- Add `ULabel.get_resize_toolbox_item()` static method to get the `AnnotationResizeItem` class, which has static methods that allow for programmatic control of annotation size for subtasks.
+
 ## [0.23.0] - Jan 16th, 2026
 - Add vertex deletion keybind for polygon and polyline annotations
   - New configurable `delete_vertex_keybind` (default: `x`)

--- a/api_spec.md
+++ b/api_spec.md
@@ -353,6 +353,18 @@ You can access the AllowedToolboxItem enum by calling the static method:
 const AllowedToolboxItem = ULabel.get_allowed_toolbox_item_enum();
 ```
 
+### `AnnotationResizeItem`
+The `AnnotationResizeItem` can be used to programmatically control annotation size for subtasks. It can be accessed with the static method:
+```javascript
+const AnnotationResizeItem = ULabel.get_resize_toolbox_item();
+```
+Using the class, you can call any of its static methods by passing in your `ULabel` instance, the key of the subtask you want to modify, and any other required arguments. For example:
+
+```javascript
+AnnotationResizeItem.toggle_subtask_vanished(ulabel, subtask_key);
+```
+Note that in order to work, the `AnnotationResize` toolbox item MUST be present in your `ULabel` instance.
+
 ### `distance_filter_toolbox_item`
 Configuration object for the `FilterDistance` toolbox item with the following custom definitions:
 ```javascript

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ import { ULabelAnnotation } from "./src/annotation";
 import { AllowedToolboxItem, Configuration } from "./src/configuration";
 import { FilterDistanceOverlay } from "./src/overlays";
 import { ULabelSubtask } from "./src/subtask";
-import { Toolbox } from "./src/toolbox";
+import { Toolbox, AnnotationResizeItem } from "./src/toolbox";
 
 export type DistanceFromPolyline = {
     distance: number;
@@ -361,6 +361,7 @@ export class ULabel {
     // Static functions
     static get_time(): string;
     static get_allowed_toolbox_item_enum(): AllowedToolboxItem;
+    static get_resize_toolbox_item(): AnnotationResizeItem;
     static process_classes(ulabel_obj: ULabel, arg1: string, subtask_obj: ULabelSubtask): void;
     static build_id_dialogs(ulabel_obj: ULabel): void;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ulabel",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ulabel",
-      "version": "0.23.0",
+      "version": "0.23.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/config-inspector": "^1.3.0",
@@ -70,7 +70,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -3914,7 +3913,6 @@
       "integrity": "sha512-6JSSaBZmsKvEkbRUkf7Zj7dru/8ZCrJxAqArcLaVMee5907JdtEbKGsZ7zNiIm/UAkpGUkaSMZEXShnN2D1HZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.1",
         "@typescript-eslint/types": "8.46.1",
@@ -4378,7 +4376,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4844,7 +4841,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -5948,7 +5944,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -6051,7 +6046,6 @@
       "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10012,7 +10006,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10620,7 +10613,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10791,7 +10783,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
       "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11033,7 +11024,6 @@
       "integrity": "sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -11082,7 +11072,6 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
       "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,23 @@
 {
   "name": "ulabel",
   "description": "An image annotation tool.",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "main": "dist/ulabel.min.js",
   "module": "dist/ulabel.min.js",
+  "types": "index.d.ts",
   "exports": {
-    ".": "./dist/ulabel.min.js",
-    "./min": "./dist/ulabel.min.js",
-    "./debug": "./dist/ulabel.js"
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./dist/ulabel.min.js"
+    },
+    "./min": {
+      "types": "./index.d.ts",
+      "default": "./dist/ulabel.min.js"
+    },
+    "./debug": {
+      "types": "./index.d.ts",
+      "default": "./dist/ulabel.js"
+    }
   },
   "scripts": {
     "test": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192\" jest",

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ import {
     mark_deprecated,
     update_distance_from_line_to_each_point,
 } from "../build/annotation_operators";
-import { AnnotationResizeItem } from "../build/toolbox";
+import { AnnotationResizeItem, BrushToolboxItem } from "../build/toolbox";
 import { remove_ulabel_listeners } from "../build/listeners";
 import { log_message, LogLevel } from "../build/error_logging";
 import { initialize_annotation_canvases } from "../build/canvas_utils";
@@ -48,7 +48,6 @@ import {
     BACK_Z_INDEX,
 } from "./blobs";
 import { ULABEL_VERSION } from "./version";
-import { BrushToolboxItem } from "../build/toolbox";
 import { ulabel_init } from "../build/initializer";
 
 jQuery.fn.outer_html = function () {

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ import {
     mark_deprecated,
     update_distance_from_line_to_each_point,
 } from "../build/annotation_operators";
-
+import { AnnotationResizeItem } from "../build/toolbox";
 import { remove_ulabel_listeners } from "../build/listeners";
 import { log_message, LogLevel } from "../build/error_logging";
 import { initialize_annotation_canvases } from "../build/canvas_utils";
@@ -69,6 +69,10 @@ export class ULabel {
 
     static get_allowed_toolbox_item_enum() {
         return AllowedToolboxItem;
+    }
+
+    static get_resize_toolbox_item() {
+        return AnnotationResizeItem;
     }
 
     /*

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export const ULABEL_VERSION = "0.23.0";
+export const ULABEL_VERSION = "0.23.1";

--- a/tests/ulabel.test.js
+++ b/tests/ulabel.test.js
@@ -96,6 +96,12 @@ describe("ULabel Core Functionality", () => {
             const enum_obj = ULabel.get_allowed_toolbox_item_enum();
             expect(typeof enum_obj).toBe("object");
         });
+
+        test("should return resize toolbox item class", () => {
+            const resize_item_class = ULabel.get_resize_toolbox_item();
+            expect(typeof resize_item_class).toBe("function");
+            expect(resize_item_class.name).toBe("AnnotationResizeItem");
+        });
     });
 
     describe("Class Processing", () => {

--- a/tests/ulabel.test.js
+++ b/tests/ulabel.test.js
@@ -100,7 +100,10 @@ describe("ULabel Core Functionality", () => {
         test("should return resize toolbox item class", () => {
             const resize_item_class = ULabel.get_resize_toolbox_item();
             expect(typeof resize_item_class).toBe("function");
-            expect(resize_item_class.name).toBe("AnnotationResizeItem");
+            // Verify class methods
+            expect(typeof resize_item_class.update_annotation_size).toBe("function");
+            expect(typeof resize_item_class.update_subtask_line_size).toBe("function");
+            expect(typeof resize_item_class.toggle_subtask_vanished).toBe("function");
         });
     });
 


### PR DESCRIPTION
# fix/type-export

## Description
- Fix export of typescript types
- Add `ULabel.get_resize_toolbox_item()` static method to get the `AnnotationResizeItem` class, which has static methods that allow for programmatic control of annotation size for subtasks.

## PR Checklist

- [x] Merged latest main
- [x] Version number in `package.json` has been bumped since last release
- [x] Version numbers match between package `package.json` and `src/version.js`
- [x] Updated documentation if necessary (currently just in `api_spec.md`)
- [x] Added changes to `changelog.md`

## Breaking API Changes
No
