### PR TITLE
fix button name bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented here.
 
 ## [unreleased]
 
+## [0.23.2] - Mar 18th, 2026
+- Fix bug where multiple spaces in a submit button name would cause the button hook to not fire.
+
 ## [0.23.1] - Mar 18th, 2026
 - Fix export of typescript types
 - Add `ULabel.get_resize_toolbox_item()` static method to get the `AnnotationResizeItem` class, which has static methods that allow for programmatic control of annotation size for subtasks.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ulabel",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ulabel",
-      "version": "0.23.1",
+      "version": "0.23.2",
       "license": "MIT",
       "devDependencies": {
         "@eslint/config-inspector": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ulabel",
   "description": "An image annotation tool.",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "main": "dist/ulabel.min.js",
   "module": "dist/ulabel.min.js",
   "types": "index.d.ts",

--- a/src/toolbox_items/submit_buttons.ts
+++ b/src/toolbox_items/submit_buttons.ts
@@ -168,7 +168,7 @@ export class SubmitButtons extends ToolboxItem {
         // Remove everything except alphanumeric, dash, underscore, space
         let submit_button_id = submit_button.name.replace(/[^a-zA-Z0-9-_ ]/g, "");
 
-        submit_button_id = submit_button_id.trim().toLowerCase().replace(" ", "-");
+        submit_button_id = submit_button_id.trim().toLowerCase().replace(/ /g, "-");
         return submit_button_id;
     }
 

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export const ULABEL_VERSION = "0.23.1";
+export const ULABEL_VERSION = "0.23.2";


### PR DESCRIPTION
# fix button name bug

## Description
- Fix bug where multiple spaces in a submit button name would cause the button hook to not fire.

## PR Checklist

- [x] Merged latest main
- [x] Version number in `package.json` has been bumped since last release
- [x] Version numbers match between package `package.json` and `src/version.js`
- [x] Updated documentation if necessary (currently just in `api_spec.md`)
- [x] Added changes to `changelog.md`

## Breaking API Changes
No
