### PR TITLE
Fix/slider value

### DIFF
--- a/.github/tasks.md
+++ b/.github/tasks.md
@@ -1,17 +1,2 @@
 ## Tasks
-- [x] Read the discussion in issue [#159](https://github.com/SenteraLLC/ulabel/issues/159)
-- [x] Implement a vertex deletion keybind for polygon and polyline spatial types it should:
-  - [x] Delete the vertex when pressed when hovering over it such that the edit suggestion is showing
-  - [x] Delete the vertex when pressed when dragging/editing the vertex
-  - [x] For polylines, if only one point remains in the polyline, it should delete the polyline
-  - [x] For polygons, if fewer than 3 points remain in a polygon layer, the layer should be removed
-- [x] Add a test for the keybind in keybind-functionality.spec.js
-- [x] Update the api_spec and changelog
-- [ ] Add public API methods to expose keypoint slider and distance filter slider values
-  - [x] Add `get_current_value()` to `KeypointSliderItem` in toolbox.ts
-  - [x] Add `get_current_values()` to `FilterPointDistanceFromRow` in toolbox.ts
-  - [x] Add `get_keypoint_slider_value()` and `get_distance_filter_value()` to ULabel in index.js
-  - [x] Update type definitions in index.d.ts
-  - [x] Update api_spec.md and CHANGELOG.md
-  - [ ] Build and lint
-
+- 

--- a/.github/tasks.md
+++ b/.github/tasks.md
@@ -7,4 +7,11 @@
   - [x] For polygons, if fewer than 3 points remain in a polygon layer, the layer should be removed
 - [x] Add a test for the keybind in keybind-functionality.spec.js
 - [x] Update the api_spec and changelog
+- [ ] Add public API methods to expose keypoint slider and distance filter slider values
+  - [x] Add `get_current_value()` to `KeypointSliderItem` in toolbox.ts
+  - [x] Add `get_current_values()` to `FilterPointDistanceFromRow` in toolbox.ts
+  - [x] Add `get_keypoint_slider_value()` and `get_distance_filter_value()` to ULabel in index.js
+  - [x] Update type definitions in index.d.ts
+  - [x] Update api_spec.md and CHANGELOG.md
+  - [ ] Build and lint
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented here.
 
 ## [unreleased]
 
+## [0.23.3] - Mar 18th, 2026
+- Add `get_keypoint_slider_value()` public API method to get the current keypoint slider value (0-1).
+- Add `get_distance_filter_value()` public API method to get the current distance filter slider values.
+
 ## [0.23.2] - Mar 18th, 2026
 - Fix bug where multiple spaces in a submit button name would cause the button hook to not fire.
 

--- a/api_spec.md
+++ b/api_spec.md
@@ -559,6 +559,14 @@ Sets the zoom to focus on the provided annotation id, and switches to its subtas
 ### `fly_to_annotation(annotation, subtask_key, max_zoom)`
 Sets the zoom to focus on the provided annotation, and switches to its subtask if provided. Returns `true` on success and `false` on failure (eg, annotation doesn't exist in subtask, is not a spatial annotation, or is deprecated).
 
+### `get_keypoint_slider_value()`
+
+*() => number | null* -- Returns the current keypoint slider value as a number between 0 and 1. Returns `null` if the KeypointSlider toolbox item is not active or the slider element is not found.
+
+### `get_distance_filter_value()`
+
+*() => object | null* -- Returns an object mapping class identifiers to their distance filter values (in pixels). The object always includes a `closest_row` key for the single-class slider. In multi-class mode, additional keys correspond to each class ID. Returns `null` if the FilterDistance toolbox item is not active or no sliders are found.
+
 ## Generic Callbacks
 
 Callbacks can be provided by calling `.on(fn, callback)` on a `ULabel` object.

--- a/index.d.ts
+++ b/index.d.ts
@@ -338,6 +338,8 @@ export class ULabel {
         force_filter_all?: boolean,
         offset?: Offset,
     ): void;
+    public get_keypoint_slider_value(): number | null;
+    public get_distance_filter_value(): DistanceFromPolylineClasses | null;
     public fly_to_next_annotation(increment: number, max_zoom?: number): boolean;
     public fly_to_annotation_id(annotation_id: string, subtask_key?: string, max_zoom?: number): boolean;
     public fly_to_annotation(annotation: ULabelAnnotation, subtask_key?: string, max_zoom?: number): boolean;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ulabel",
-  "version": "0.23.2",
+  "version": "0.23.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ulabel",
-      "version": "0.23.2",
+      "version": "0.23.3",
       "license": "MIT",
       "devDependencies": {
         "@eslint/config-inspector": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ulabel",
   "description": "An image annotation tool.",
-  "version": "0.23.2",
+  "version": "0.23.3",
   "main": "dist/ulabel.min.js",
   "module": "dist/ulabel.min.js",
   "types": "index.d.ts",

--- a/src/annotation_operators.ts
+++ b/src/annotation_operators.ts
@@ -10,7 +10,7 @@ import type {
 // Import ULabel from ../src/index - TypeScript will find ../src/index.d.ts for types
 import { ULabel } from "../src/index";
 
-import { ULabelAnnotation } from "./annotation";
+import { ULabelAnnotation, DELETE_CLASS_ID } from "./annotation";
 import { ULabelSubtask } from "./subtask";
 
 /**
@@ -582,6 +582,8 @@ export function findAllPolylineClassDefinitions(ulabel: ULabel) {
         if (subtask.allowed_modes.includes("polyline")) {
             // Loop through all the classes in the subtask
             subtask.class_defs.forEach((current_class_def) => {
+                // Skip the reserved delete class
+                if (current_class_def.id === DELETE_CLASS_ID) return;
                 potential_class_defs.push(current_class_def);
             });
         }

--- a/src/index.js
+++ b/src/index.js
@@ -1020,6 +1020,32 @@ export class ULabel {
         }
     }
 
+    /**
+     * Get the current keypoint slider value.
+     *
+     * @returns {number|null} The current slider value as a number between 0 and 1,
+     *   or null if the KeypointSlider toolbox item is not active or the slider is not found
+     */
+    get_keypoint_slider_value() {
+        if (!this.config.toolbox_order.includes(AllowedToolboxItem.KeypointSlider)) return null;
+        const item = this.toolbox.items.find((item) => item.get_toolbox_item_type() === "KeypointSlider");
+        if (item === undefined) return null;
+        return item.get_current_value();
+    }
+
+    /**
+     * Get the current distance filter slider values.
+     *
+     * @returns {object|null} An object mapping class identifiers to their distance values,
+     *   or null if the FilterDistance toolbox item is not active or no sliders are found
+     */
+    get_distance_filter_value() {
+        if (!this.config.toolbox_order.includes(AllowedToolboxItem.FilterDistance)) return null;
+        const item = this.toolbox.items.find((item) => item.get_toolbox_item_type() === "FilterDistance");
+        if (item === undefined) return null;
+        return item.get_current_values();
+    }
+
     // Show annotation mode
     show_annotation_mode(el = null) {
         if (el === null) {

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -1947,6 +1947,17 @@ export class KeypointSliderItem extends ToolboxItem {
         `;
     }
 
+    /**
+     * Get the current keypoint slider value by reading the DOM slider element.
+     *
+     * @returns The current slider value as a number between 0 and 1, or null if the slider is not found
+     */
+    public get_current_value(): number | null {
+        const slider: HTMLInputElement = document.querySelector(`#${this.slider_bar_id}`);
+        if (slider === null) return null;
+        return slider.valueAsNumber / 100;
+    }
+
     public after_init() {
         // This toolbox item doesn't need to do anything after initialization
     }
@@ -2353,6 +2364,25 @@ export class FilterPointDistanceFromRow extends ToolboxItem {
 
     public after_init() {
         // This toolbox item doesn't need to do anything after initialization
+    }
+
+    /**
+     * Get the current distance filter slider values by reading the DOM slider elements.
+     *
+     * @returns An object mapping class identifiers to their distance values, or null if no sliders are found
+     */
+    public get_current_values(): DistanceFromPolylineClasses | null {
+        const sliders: NodeListOf<HTMLInputElement> = document.querySelectorAll(".filter-row-distance-slider");
+        if (sliders.length === 0) return null;
+
+        const filter_values: DistanceFromPolylineClasses = { closest_row: undefined };
+        for (let idx = 0; idx < sliders.length; idx++) {
+            const slider_class_name = /[^-]*$/.exec(sliders[idx].id)[0];
+            filter_values[slider_class_name] = {
+                distance: sliders[idx].valueAsNumber,
+            };
+        }
+        return filter_values;
     }
 
     public get_toolbox_item_type() {

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -1953,7 +1953,7 @@ export class KeypointSliderItem extends ToolboxItem {
      * @returns The current slider value as a number between 0 and 1, or null if the slider is not found
      */
     public get_current_value(): number | null {
-        const slider: HTMLInputElement = document.querySelector(`#${this.slider_bar_id}`);
+        const slider = document.querySelector<HTMLInputElement>(`#${this.slider_bar_id}`);
         if (slider === null) return null;
         return slider.valueAsNumber / 100;
     }
@@ -2372,7 +2372,7 @@ export class FilterPointDistanceFromRow extends ToolboxItem {
      * @returns An object mapping class identifiers to their distance values, or null if no sliders are found
      */
     public get_current_values(): DistanceFromPolylineClasses | null {
-        const sliders: NodeListOf<HTMLInputElement> = document.querySelectorAll(".filter-row-distance-slider");
+        const sliders = document.querySelectorAll<HTMLInputElement>(".filter-row-distance-slider");
         if (sliders.length === 0) return null;
 
         const filter_values: DistanceFromPolylineClasses = { closest_row: undefined };

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -2372,7 +2372,11 @@ export class FilterPointDistanceFromRow extends ToolboxItem {
      * @returns An object mapping class identifiers to their distance values, or null if no sliders are found
      */
     public get_current_values(): DistanceFromPolylineClasses | null {
-        const sliders = document.querySelectorAll<HTMLInputElement>(".filter-row-distance-slider");
+        const container_id = this.multi_class_mode ? "filter-multi-class-mode" : "filter-single-class-mode";
+        const container = document.getElementById(container_id);
+        if (container === null) return null;
+
+        const sliders = container.querySelectorAll<HTMLInputElement>(".filter-row-distance-slider");
         if (sliders.length === 0) return null;
 
         const filter_values: DistanceFromPolylineClasses = { closest_row: undefined };

--- a/src/toolbox.ts
+++ b/src/toolbox.ts
@@ -2372,20 +2372,31 @@ export class FilterPointDistanceFromRow extends ToolboxItem {
      * @returns An object mapping class identifiers to their distance values, or null if no sliders are found
      */
     public get_current_values(): DistanceFromPolylineClasses | null {
-        const container_id = this.multi_class_mode ? "filter-multi-class-mode" : "filter-single-class-mode";
-        const container = document.getElementById(container_id);
-        if (container === null) return null;
+        // Always read the single-class slider for closest_row
+        const single_container = document.getElementById("filter-single-class-mode");
+        if (single_container === null) return null;
 
-        const sliders = container.querySelectorAll<HTMLInputElement>(".filter-row-distance-slider");
-        if (sliders.length === 0) return null;
+        const single_slider = single_container.querySelector<HTMLInputElement>(".filter-row-distance-slider");
+        if (single_slider === null) return null;
 
-        const filter_values: DistanceFromPolylineClasses = { closest_row: undefined };
-        for (let idx = 0; idx < sliders.length; idx++) {
-            const slider_class_name = /[^-]*$/.exec(sliders[idx].id)[0];
-            filter_values[slider_class_name] = {
-                distance: sliders[idx].valueAsNumber,
-            };
+        const filter_values: DistanceFromPolylineClasses = {
+            closest_row: { distance: single_slider.valueAsNumber },
+        };
+
+        // In multi-class mode, also read the per-class sliders
+        if (this.multi_class_mode) {
+            const multi_container = document.getElementById("filter-multi-class-mode");
+            if (multi_container !== null) {
+                const sliders = multi_container.querySelectorAll<HTMLInputElement>(".filter-row-distance-slider");
+                for (let idx = 0; idx < sliders.length; idx++) {
+                    const slider_class_name = /[^-]*$/.exec(sliders[idx].id)[0];
+                    filter_values[slider_class_name] = {
+                        distance: sliders[idx].valueAsNumber,
+                    };
+                }
+            }
         }
+
         return filter_values;
     }
 

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export const ULABEL_VERSION = "0.23.2";
+export const ULABEL_VERSION = "0.23.3";

--- a/tests/e2e/slider-api.spec.js
+++ b/tests/e2e/slider-api.spec.js
@@ -1,0 +1,80 @@
+// End-to-end tests for slider public API methods
+import { test, expect } from "./fixtures";
+import { wait_for_ulabel_init } from "../testing-utils/init_utils";
+
+test.describe("Slider Public API", () => {
+    test.describe("get_keypoint_slider_value", () => {
+        test("should return default keypoint slider value after init", async ({ page }) => {
+            await wait_for_ulabel_init(page);
+
+            const value = await page.evaluate(() => window.ulabel.get_keypoint_slider_value());
+
+            // Default keypoint_slider_default_value is 0, so the slider should be at 0
+            expect(value).toBe(0);
+        });
+
+        test("should reflect value after moving the slider", async ({ page }) => {
+            await wait_for_ulabel_init(page);
+
+            // Set the slider to 75 (out of 100) via the DOM
+            await page.evaluate(() => {
+                const slider = document.querySelector("#keypoint-slider");
+                slider.value = "75";
+                slider.dispatchEvent(new Event("input", { bubbles: true }));
+            });
+
+            const value = await page.evaluate(() => window.ulabel.get_keypoint_slider_value());
+
+            // Value should be 0.75 (75 / 100)
+            expect(value).toBe(0.75);
+        });
+
+        test("should return a number between 0 and 1", async ({ page }) => {
+            await wait_for_ulabel_init(page);
+
+            const value = await page.evaluate(() => window.ulabel.get_keypoint_slider_value());
+
+            expect(typeof value).toBe("number");
+            expect(value).toBeGreaterThanOrEqual(0);
+            expect(value).toBeLessThanOrEqual(1);
+        });
+    });
+
+    test.describe("get_distance_filter_value", () => {
+        test("should return default distance filter value after init", async ({ page }) => {
+            await wait_for_ulabel_init(page);
+
+            const value = await page.evaluate(() => window.ulabel.get_distance_filter_value());
+
+            // Should have at least the closest_row key with the default distance of 40
+            expect(value).not.toBeNull();
+            expect(value.closest_row).toBeDefined();
+            expect(value.closest_row.distance).toBe(40);
+        });
+
+        test("should reflect value after moving the slider", async ({ page }) => {
+            await wait_for_ulabel_init(page);
+
+            // Set the distance filter slider to 200
+            await page.evaluate(() => {
+                const slider = document.querySelector("#filter-row-distance-closest_row");
+                slider.value = "200";
+                slider.dispatchEvent(new Event("input", { bubbles: true }));
+            });
+
+            const value = await page.evaluate(() => window.ulabel.get_distance_filter_value());
+
+            expect(value.closest_row.distance).toBe(200);
+        });
+
+        test("should return an object with closest_row key", async ({ page }) => {
+            await wait_for_ulabel_init(page);
+
+            const value = await page.evaluate(() => window.ulabel.get_distance_filter_value());
+
+            expect(typeof value).toBe("object");
+            expect(value).toHaveProperty("closest_row");
+            expect(typeof value.closest_row.distance).toBe("number");
+        });
+    });
+});


### PR DESCRIPTION
# Fix/slider value

## Description
- Add `get_keypoint_slider_value()` public API method to get the current keypoint slider value (0-1).
- Add `get_distance_filter_value()` public API method to get the current distance filter slider values.

## PR Checklist

- [x] Merged latest main
- [x] Version number in `package.json` has been bumped since last release
- [x] Version numbers match between package `package.json` and `src/version.js`
- [x] Updated documentation if necessary (currently just in `api_spec.md`)
- [x] Added changes to `changelog.md`

## Breaking API Changes
No
